### PR TITLE
Remove exit 1 to avoid breaking workflow trace span

### DIFF
--- a/aws/react-bedrock3.py
+++ b/aws/react-bedrock3.py
@@ -52,7 +52,7 @@ class ChatBot:
 
         except (ClientError, Exception) as e:
             print(f"ERROR: Can't invoke '{model_id}'. Reason: {e}")
-            exit(1)
+            return None
 
         # Decode the response body.
         model_response = json.loads(response["body"].read())
@@ -142,6 +142,8 @@ action_re = re.compile('^Action: (\w+): (.*)$')
 def query(question, max_turns=3):
     i = 0
     bot = ChatBot(prompt)
+    if bot == None:
+        return
     next_prompt = question
     while i < max_turns:
         i += 1

--- a/aws/react-bedrock3.py
+++ b/aws/react-bedrock3.py
@@ -142,7 +142,8 @@ action_re = re.compile('^Action: (\w+): (.*)$')
 def query(question, max_turns=3):
     i = 0
     bot = ChatBot(prompt)
-    if bot == None:
+    if bot is None:
+        print("Error: ChatBot initialization failed")
         return
     next_prompt = question
     while i < max_turns:


### PR DESCRIPTION
The exit(1) will directly terminate the program, which will disrupt the trace of workflow span.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in the ChatBot class to prevent program termination on errors.
	- Added a check for proper initialization of the ChatBot to enhance workflow robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->