### PR TITLE
docs(llm-d-full-demo): fix gateway observability guide ordering after re-run

### DIFF
--- a/llm-d/llm-d-full-demo/GATEWAY-OBSERVABILITY-zh.md
+++ b/llm-d/llm-d-full-demo/GATEWAY-OBSERVABILITY-zh.md
@@ -160,9 +160,22 @@ chart 还会创建到 Gateway 的 `HTTPRoute`。
 让 EPP 运行 `precise-prefix-cache-producer` + `token-producer`，对接 vLLM 在 ZMQ `:5556`
 上的 KV-events。chart 会在 EPP Pod 里部署 `vllm-render` sidecar 做分词。
 
-先安装 monitoring CRDs（Helm chart 会创建 `ServiceMonitor`）：
+> **顺序很重要：** chart 会在 EPP Pod 里部署 `vllm-render` sidecar，它在启动时**就**需要
+> vLLM 镜像**和** `llm-d-hf-token` secret。务必在装 chart **之前**把两者准备好，否则 EPP Pod
+> 会卡在 `1/2 CreateContainerConfigError`（`secret "llm-d-hf-token" not found`）。
 
 ```console
+gyliu-cary@Mac llm-d % # (a) vLLM 镜像 —— kind load 对这个多架构 manifest list 会失败，
+gyliu-cary@Mac llm-d %  #     改用 ctr 导入到节点：
+gyliu-cary@Mac llm-d % docker pull --platform linux/arm64 docker.io/vllm/vllm-openai-cpu:v0.19.1
+gyliu-cary@Mac llm-d % docker save docker.io/vllm/vllm-openai-cpu:v0.19.1 | \
+  docker exec -i llm-d-control-plane ctr -n k8s.io images import -
+gyliu-cary@Mac llm-d % # (b) HF token secret（先 cp .env.example -> .env 并填好 HF_TOKEN）
+gyliu-cary@Mac llm-d % cp $DEMO/.env.example $DEMO/.env   # 编辑 HF_TOKEN
+gyliu-cary@Mac llm-d % set -a && source $DEMO/.env && set +a
+gyliu-cary@Mac llm-d % kubectl create secret generic llm-d-hf-token -n llm-d \
+  --from-literal=HF_TOKEN="$HF_TOKEN" --dry-run=client -o yaml | kubectl apply -f -
+gyliu-cary@Mac llm-d % # (c) monitoring CRDs（chart 会创建 ServiceMonitor）
 gyliu-cary@Mac llm-d % bash $LLMD_REPO/guides/recipes/observability/install-prometheus-grafana.sh --crds-only
 gyliu-cary@Mac llm-d % helm install llm-d oci://ghcr.io/llm-d/charts/llm-d-router-gateway-dev \
   -f $LLMD_REPO/guides/recipes/router/base.values.yaml \
@@ -179,7 +192,7 @@ NAME                                        HOSTNAMES   AGE
 httproute.gateway.networking.k8s.io/llm-d               5s
 NAME                                              AGE
 inferencepool.inference.networking.k8s.io/llm-d   5s
-gyliu-cary@Mac llm-d % kubectl get pod -n llm-d -l app.kubernetes.io/name=llm-d-epp \
+gyliu-cary@Mac llm-d % kubectl get pod -n llm-d -l llm-d-router-gateway=llm-d-epp \
   -o jsonpath='EPP containers: {.items[0].spec.containers[*].name}{"\n"}'
 EPP containers: epp vllm-render
 ```
@@ -207,22 +220,15 @@ router:
 
 `vllm/vllm-openai-cpu:v0.19.1` 镜像有 **arm64** 变体（原生，无需模拟）。
 服务 `Qwen2.5-0.5B-Instruct`，block-size 64，在 ZMQ `:5556` 发 KV-events。
+镜像和 `llm-d-hf-token` secret 已在 3.7 准备好；这里只建 ServiceAccount 和 Deployment。
 
 ```console
-gyliu-cary@Mac llm-d % docker pull --platform linux/arm64 docker.io/vllm/vllm-openai-cpu:v0.19.1
-gyliu-cary@Mac llm-d % kind load docker-image docker.io/vllm/vllm-openai-cpu:v0.19.1 --name llm-d
-# 若 kind load 报 "content digest ... not found"（Docker Desktop 多架构 manifest list），
-# 改用 ctr 导入：
-# docker save docker.io/vllm/vllm-openai-cpu:v0.19.1 | \
-#   docker exec -i llm-d-control-plane ctr -n k8s.io images import -
-gyliu-cary@Mac llm-d % cp $DEMO/.env.example $DEMO/.env   # 编辑 HF_TOKEN
-gyliu-cary@Mac llm-d % set -a && source $DEMO/.env && set +a
-gyliu-cary@Mac llm-d % kubectl create secret generic llm-d-hf-token -n llm-d \
-  --from-literal=HF_TOKEN="$HF_TOKEN" --dry-run=client -o yaml | kubectl apply -f -
-# model-server.yaml 引用 serviceAccountName: sa — 需先创建（provider.name=none 时 chart 不会创建）：
+gyliu-cary@Mac llm-d % # model-server.yaml 引用 serviceAccountName: sa —— 需先创建
+gyliu-cary@Mac llm-d %  #     （provider.name=none 时 chart 不会创建）：
 gyliu-cary@Mac llm-d % kubectl apply -f $LLMD_REPO/guides/recipes/modelserver/common/sa.yaml -n llm-d
 gyliu-cary@Mac llm-d % kubectl apply -f $DEMO/manifests/optional/cpu-vllm/model-server.yaml
 gyliu-cary@Mac llm-d % kubectl rollout status deploy/precise-prefix-vllm -n llm-d --timeout=600s
+deployment "precise-prefix-vllm" successfully rolled out
 ```
 
 > **Rollout 一直卡在 `0 out of 1 new replicas`？** 看事件：

--- a/llm-d/llm-d-full-demo/GATEWAY-OBSERVABILITY.md
+++ b/llm-d/llm-d-full-demo/GATEWAY-OBSERVABILITY.md
@@ -162,9 +162,23 @@ Use **`precise-prefix-router.values.yaml`** (not `optimized-baseline.values.yaml
 EPP runs `precise-prefix-cache-producer` + `token-producer` against the real vLLM KV-events
 on ZMQ `:5556`. The chart deploys a `vllm-render` sidecar in the EPP pod for tokenization.
 
-Install monitoring CRDs first (the chart creates a `ServiceMonitor`):
+> **Important ordering:** the chart deploys the `vllm-render` sidecar in the EPP pod, which
+> needs the vLLM image **and** the `llm-d-hf-token` secret at startup. Load/create both
+> **before** installing the chart, otherwise the EPP pod stays at
+> `1/2 CreateContainerConfigError` (`secret "llm-d-hf-token" not found`).
 
 ```console
+gyliu-cary@Mac llm-d % # (a) vLLM image -- kind load fails for this multi-arch manifest list,
+gyliu-cary@Mac llm-d %  #     so import it into the node via ctr:
+gyliu-cary@Mac llm-d % docker pull --platform linux/arm64 docker.io/vllm/vllm-openai-cpu:v0.19.1
+gyliu-cary@Mac llm-d % docker save docker.io/vllm/vllm-openai-cpu:v0.19.1 | \
+  docker exec -i llm-d-control-plane ctr -n k8s.io images import -
+gyliu-cary@Mac llm-d % # (b) HF token secret (copy .env.example -> .env, set HF_TOKEN)
+gyliu-cary@Mac llm-d % cp $DEMO/.env.example $DEMO/.env   # then edit HF_TOKEN
+gyliu-cary@Mac llm-d % set -a && source $DEMO/.env && set +a
+gyliu-cary@Mac llm-d % kubectl create secret generic llm-d-hf-token -n llm-d \
+  --from-literal=HF_TOKEN="$HF_TOKEN" --dry-run=client -o yaml | kubectl apply -f -
+gyliu-cary@Mac llm-d % # (c) monitoring CRDs (the chart creates a ServiceMonitor)
 gyliu-cary@Mac llm-d % bash $LLMD_REPO/guides/recipes/observability/install-prometheus-grafana.sh --crds-only
 gyliu-cary@Mac llm-d % helm install llm-d oci://ghcr.io/llm-d/charts/llm-d-router-gateway-dev \
   -f $LLMD_REPO/guides/recipes/router/base.values.yaml \
@@ -181,7 +195,7 @@ NAME                                        HOSTNAMES   AGE
 httproute.gateway.networking.k8s.io/llm-d               5s
 NAME                                              AGE
 inferencepool.inference.networking.k8s.io/llm-d   5s
-gyliu-cary@Mac llm-d % kubectl get pod -n llm-d -l app.kubernetes.io/name=llm-d-epp \
+gyliu-cary@Mac llm-d % kubectl get pod -n llm-d -l llm-d-router-gateway=llm-d-epp \
   -o jsonpath='EPP containers: {.items[0].spec.containers[*].name}{"\n"}'
 EPP containers: epp vllm-render
 ```
@@ -209,23 +223,16 @@ router:
 
 The `vllm/vllm-openai-cpu:v0.19.1` image has an **arm64** variant (native, no emulation).
 Serves `Qwen2.5-0.5B-Instruct`, block-size 64, publishing KV-events on ZMQ `:5556`.
+The image and the `llm-d-hf-token` secret were already prepared in Step 3.7; here we only
+create the ServiceAccount and the Deployment.
 
 ```console
-gyliu-cary@Mac llm-d % docker pull --platform linux/arm64 docker.io/vllm/vllm-openai-cpu:v0.19.1
-gyliu-cary@Mac llm-d % kind load docker-image docker.io/vllm/vllm-openai-cpu:v0.19.1 --name llm-d
-# If kind load fails with "content digest ... not found" (multi-arch manifest list on
-# Docker Desktop), import via ctr instead:
-# docker save docker.io/vllm/vllm-openai-cpu:v0.19.1 | \
-#   docker exec -i llm-d-control-plane ctr -n k8s.io images import -
-gyliu-cary@Mac llm-d % cp $DEMO/.env.example $DEMO/.env   # then edit HF_TOKEN
-gyliu-cary@Mac llm-d % set -a && source $DEMO/.env && set +a
-gyliu-cary@Mac llm-d % kubectl create secret generic llm-d-hf-token -n llm-d \
-  --from-literal=HF_TOKEN="$HF_TOKEN" --dry-run=client -o yaml | kubectl apply -f -
-# Model-server manifest references serviceAccountName: sa — create it before the Deployment
-# (the gateway chart with provider.name=none does not create it):
+gyliu-cary@Mac llm-d % # Model-server manifest references serviceAccountName: sa -- create it
+gyliu-cary@Mac llm-d %  #     first (the gateway chart with provider.name=none does not):
 gyliu-cary@Mac llm-d % kubectl apply -f $LLMD_REPO/guides/recipes/modelserver/common/sa.yaml -n llm-d
 gyliu-cary@Mac llm-d % kubectl apply -f $DEMO/manifests/optional/cpu-vllm/model-server.yaml
 gyliu-cary@Mac llm-d % kubectl rollout status deploy/precise-prefix-vllm -n llm-d --timeout=600s
+deployment "precise-prefix-vllm" successfully rolled out
 ```
 
 > **Rollout stuck at `0 out of 1 new replicas`?** Check events:


### PR DESCRIPTION
## Summary

Re-ran the `GATEWAY-OBSERVABILITY.md` guide end-to-end on a **fresh Kind cluster** to verify
one-pass success. The stack came up and both tracing and metrics closed loops passed, but
three issues blocked a clean first run. This PR fixes them in both the EN and ZH docs.

## Fixes

1. **Ordering** — load the vLLM image and create the `llm-d-hf-token` secret **before** Step 3.7.
   The router chart deploys a `vllm-render` sidecar in the EPP pod that needs both at startup;
   otherwise the EPP pod is stuck at `1/2 CreateContainerConfigError`
   (`secret "llm-d-hf-token" not found`).
2. **vLLM image import** — make `ctr` import the primary method. `kind load` reliably fails for
   this multi-arch manifest list (`ctr: content digest ... not found`); it was only a fallback note before.
3. **Label selector** — the 3.7 verification command used `app.kubernetes.io/name=llm-d-epp`,
   which returns nothing; the gateway-dev chart labels the EPP pod `llm-d-router-gateway=llm-d-epp`.

## Verified

- `curl` through the gateway → `200`; Jaeger shows the stitched trace
  `POST /*` → `gateway.request` → `gateway.request_orchestration` → `produce_precise_prefix_cache`.
- Prometheus targets `llm-d-epp-monitor` and `decode` UP; `llm_d_epp_request_total` and `vllm:*`
  queryable; Grafana dashboards load.
- vLLM CPU rolled out first try with the `VLLM_CPU_OMP_THREADS_BIND` NUMA workaround.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Gateway API installation procedures with clarified prerequisite steps to prevent configuration errors
  * Improved pod verification commands with updated selectors
  * Streamlined deployment workflow by consolidating preparation steps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->