### PR TITLE
add multikueue minimal demo

### DIFF
--- a/kueue/multikueue-minimal-demo/.gitignore
+++ b/kueue/multikueue-minimal-demo/.gitignore
@@ -1,0 +1,2 @@
+.generated/
+*.kubeconfig

--- a/kueue/multikueue-minimal-demo/README.md
+++ b/kueue/multikueue-minimal-demo/README.md
@@ -1,0 +1,382 @@
+# MultiKueue Minimal Demo
+
+> 中文版：[README.zh-CN.md](README.zh-CN.md) · 分步操作手册：[WALKTHROUGH.md](WALKTHROUGH.md)
+
+Four components — **kind + Kueue + JobSet + KubeRay** — build a MultiKueue environment
+spanning 3 Kubernetes clusters on your laptop, and dispatch three kinds of workload
+across them: **batch/Job, JobSet and RayJob**.
+
+**No OCM, no Karmada, no ArgoCD, no multi-cluster management platform of any kind.**
+MultiKueue is a complete multi-cluster scheduler on its own; the link between clusters
+is a single kubeconfig.
+
+---
+
+## 1. Components
+
+Installed on **every** cluster (manager and workers alike):
+
+| Component | Version | Purpose | Required? |
+|---|---|---|---|
+| kind | v0.31.0 | creates the local clusters | yes |
+| Kubernetes | v1.35.0 | node image | yes (≥ 1.32) |
+| **Kueue** | v0.19.1 | queueing, quota, MultiKueue dispatch | **yes** |
+| JobSet | v0.12.0 | JobSet workload type | only if you run JobSets |
+| KubeRay | v1.6.2 | RayJob / RayCluster workload types | only if you run Ray |
+
+These versions are not arbitrary: Kueue v0.19.1 pins jobset v0.12.0 and kuberay v1.6.2 in
+its `go.mod`, so upstream e2e validates exactly this combination.
+
+The `k8s ≥ 1.32` floor comes from the `JobManagedBy` feature gate. MultiKueue stamps
+`spec.managedBy` on the Job so the manager's native Job controller keeps its hands off,
+and that gate is only enabled by default from 1.32 onwards.
+
+---
+
+## 2. Architecture
+
+```
+┌────────────────────────────────────────────────────────────────────────────┐
+│  MANAGER CLUSTER   (kind: mk-manager)          Business pods here: ZERO     │
+│                                                                             │
+│    kubectl apply  Job / JobSet / RayJob   (label: kueue.x-k8s.io/queue-name)│
+│                              │                                              │
+│                              ▼                                              │
+│    ┌──────────────────────────────────────────────────────────────────┐    │
+│    │  LocalQueue        user-queue                                     │    │
+│    │       │                                                           │    │
+│    │       ▼                                                           │    │
+│    │  ClusterQueue      cluster-queue          quota: 10 CPU / 20Gi    │    │
+│    │       │                                   (gate #1 — dispatch)    │    │
+│    │       │  admissionChecksStrategy                                  │    │
+│    │       ▼                                                           │    │
+│    │  AdmissionCheck    multikueue-check                               │    │
+│    │       │            controllerName: kueue.x-k8s.io/multikueue      │    │
+│    │       │  parameters                                               │    │
+│    │       ▼                                                           │    │
+│    │  MultiKueueConfig  multikueue-config                              │    │
+│    │       │            clusters: [ mk-worker1, mk-worker2 ]           │    │
+│    │       ├───────────────────────────┬───────────────────────────┐   │    │
+│    │       ▼                           ▼                           │   │    │
+│    │  MultiKueueCluster           MultiKueueCluster                │   │    │
+│    │    mk-worker1                  mk-worker2                     │   │    │
+│    │       │ kubeConfig                │ kubeConfig                 │   │    │
+│    │       ▼ locationType: Secret      ▼                            │   │    │
+│    │  Secret                       Secret                          │   │    │
+│    │    mk-worker1-secret            mk-worker2-secret             │   │    │
+│    └───────┼───────────────────────────┼───────────────────────────────┘    │
+└────────────┼───────────────────────────┼────────────────────────────────────┘
+             │                           │
+             │  ServiceAccount token     │  ServiceAccount token
+             │  https://172.19.0.3:6443  │  https://172.19.0.4:6443
+             │  (docker "kind" network)  │
+             ▼                           ▼
+┌───────────────────────────────┐ ┌───────────────────────────────┐
+│ WORKER CLUSTER   mk-worker1   │ │ WORKER CLUSTER   mk-worker2   │
+│                               │ │                               │
+│  LocalQueue    user-queue     │ │  LocalQueue    user-queue     │ ← names MUST
+│       │                       │ │       │                       │   match the
+│       ▼                       │ │       ▼                       │   manager
+│  ClusterQueue  cluster-queue  │ │  ClusterQueue  cluster-queue  │
+│       quota: 2 CPU / 4Gi      │ │       quota: 2 CPU / 4Gi      │ ← gate #2
+│       (the REAL admission)    │ │       (the REAL admission)    │   real capacity
+│                               │ │                               │
+│  ▶▶ Pods actually run here    │ │  ▶▶ Pods actually run here    │
+└───────────────────────────────┘ └───────────────────────────────┘
+```
+
+### Three rules to memorise
+
+1. **Worker namespaces and LocalQueue names must match the manager exactly.**
+   MultiKueue copies the Workload verbatim; a missing same-named LocalQueue stalls it.
+
+2. **`integrations.frameworks` must match the operators actually installed on the workers.**
+   The manager opens a watch per enabled framework on every worker; a missing CRD kills the
+   whole connection. See [pitfall #1](WALKTHROUGH.md#pitfall-1-a-missing-jobset-crd-breaks-the-connection).
+
+3. **The manager never runs a business pod.** This is the most direct proof that
+   MultiKueue is working.
+
+---
+
+## 3. Workflow
+
+```
+  USER              MANAGER CLUSTER                 WORKER w1        WORKER w2
+   │                       │                            │                │
+   │ ① kubectl apply job   │                            │                │
+   │   (queue-name label)  │                            │                │
+   ├──────────────────────>│                            │                │
+   │                       │                            │                │
+   │            ┌──────────┴──────────┐                 │                │
+   │            │ ② Kueue webhook     │                 │                │
+   │            │   suspend = true    │                 │                │
+   │            │   managedBy =       │                 │                │
+   │            │   .../multikueue    │                 │                │
+   │            └──────────┬──────────┘                 │                │
+   │                       │  native Job controller     │                │
+   │                       │  sees managedBy ≠ itself   │                │
+   │                       │  → does nothing            │                │
+   │                       │                            │                │
+   │            ┌──────────┴──────────┐                 │                │
+   │            │ ③ Workload created  │                 │                │
+   │            │   GATE #1: manager  │                 │                │
+   │            │   ClusterQueue quota│                 │                │
+   │            │   → QuotaReserved   │                 │                │
+   │            └──────────┬──────────┘                 │                │
+   │                       │                            │                │
+   │            ┌──────────┴──────────┐                 │                │
+   │            │ ④ AdmissionCheck    │                 │                │
+   │            │   fires dispatcher  │                 │                │
+   │            │   AllAtOnce → both  │                 │                │
+   │            │ status.nominated    │                 │                │
+   │            │   ClusterNames      │                 │                │
+   │            └──────────┬──────────┘                 │                │
+   │                       │                            │                │
+   │                       │ ⑤ create remote Workload   │                │
+   │                       ├───────────────────────────>│                │
+   │                       ├────────────────────────────────────────────>│
+   │                       │                            │                │
+   │                       │        ⑥ GATE #2: worker ClusterQueue quota │
+   │                       │           w1 admits FIRST  │                │
+   │                       │<───────────────────────────┤                │
+   │                       │                            │                │
+   │            ┌──────────┴──────────┐                 │                │
+   │            │ ⑦ w1 wins:          │                 │                │
+   │            │  • delete the copy  │                 │                │
+   │            │    on w2  ──────────┼─────────────────┼───────────────>│ ✗
+   │            │  • status.cluster   │                 │                │
+   │            │    Name = w1        │                 │                │
+   │            │    (immutable)      │                 │                │
+   │            └──────────┬──────────┘                 │                │
+   │                       │                            │                │
+   │                       │ ⑧ create the real Job on w1│                │
+   │                       │   label: prebuilt-workload-name             │
+   │                       ├───────────────────────────>│                │
+   │                       │                            │                │
+   │                       │           ⑨ Job controller on w1 unsuspends │
+   │                       │              → PODS RUN HERE ◀◀             │
+   │                       │                            │                │
+   │                       │ ⑩ continuous status sync   │                │
+   │                       │<══════════════════════════>│                │
+   │                       │                            │                │
+   │ kubectl get job       │                            │                │
+   │<──────────────────────┤  status reflects w1's real execution        │
+   │                       │                            │                │
+   │                       │ ⑪ Workload Finished → final sync,           │
+   │                       │    then delete remote objects on w1         │
+   │                       ├───────────────────────────>│ ✗              │
+```
+
+### Observed Workload status
+
+```yaml
+status:
+  clusterName: mk-worker2            # where it ran (immutable once set)
+  admissionChecks:
+  - name: multikueue-check
+    state: Ready
+    message: The workload was admitted on "mk-worker2"
+  conditions:
+  - type: QuotaReserved              # GATE #1 — manager let it through
+    status: "True"
+    message: Quota reserved in ClusterQueue cluster-queue
+  - type: Admitted                   # GATE #2 — a worker took it
+    status: "True"
+  - type: PodsReady
+    status: "True"
+```
+
+---
+
+## 4. Quota enforcement
+
+The most commonly misunderstood part of MultiKueue: **there are two levels of quota, and
+they mean completely different things.**
+
+### Level 1 — manager ClusterQueue: a dispatch throttle, not an execution gate
+
+The manager's quota decides **how many Workloads may enter the dispatch pipeline at once**.
+A Workload must reach `QuotaReserved` on the manager before the MultiKueue AdmissionCheck
+is even triggered.
+
+This level is **notional accounting**: no pod ever consumes resources on the manager. It is
+purely an admission throttle.
+
+### Level 2 — worker ClusterQueue: the real execution gate
+
+The worker's quota is **real accounting**, mapping to that cluster's physical capacity. The
+remote Workload copy goes through a complete, standard Kueue admission there — quota,
+ResourceFlavor matching, borrowing, preemption, all of it. If the worker says no, nothing runs.
+
+### How to size the two levels
+
+Upstream guidance: **manager quota ≈ the sum of all worker quotas.**
+
+| Configuration | Consequence |
+|---|---|
+| manager quota **much lower** than the worker total | workers sit idle — the manager is throttling |
+| manager quota **much higher** than the worker total | the manager dispatches Workloads nobody can accept, creating and monitoring remote objects for nothing |
+| manager quota ≈ worker total | healthy |
+
+This demo **deliberately breaks that rule**: the manager gets 10 CPU while the two workers
+hold 2 CPU each (4 total). That is a teaching choice — it removes the manager as a
+bottleneck so you can see clearly that **the workers are the ones making the real admission
+decision**.
+
+### What that looks like
+
+Submitting 3 Jobs of 2 CPU each:
+
+```
+MANAGER — Workloads
+WORKLOAD               ADMITTED   DISPATCHED-TO
+job-demo-job-1-a9067   <none>     <none>          ← both workers full, waiting
+job-demo-job-2-dd6ff   True       mk-worker2
+job-demo-job-3-53d6e   True       mk-worker1
+
+WORKER mk-worker1: cluster-queue   PENDING 1   ADMITTED 1
+WORKER mk-worker2: cluster-queue   PENDING 1   ADMITTED 1
+```
+
+Read it like this: the manager's 10 CPU is enough for all 3 Jobs to reach `QuotaReserved`,
+so all 3 got dispatched to both workers (`PENDING 1` is the losing copy still queued). But
+each worker only has 2 CPU, so each admits exactly one. The third Job hangs —
+**the decision belongs to the workers, not the manager**.
+
+### Related features
+
+- `MultiKueueManagerQuotaAutomation` (v0.18, alpha, off by default) — lets the manager
+  aggregate quota from the workers automatically, removing the manual alignment work.
+- `ResourceFlavor` names must line up between manager and worker, or the copied Workload
+  cannot be admitted. Both sides here use `default-flavor`.
+
+---
+
+## 5. Dispatch strategy
+
+The logic that picks *which* workers get a Workload is the **dispatcher**, configured under
+`multiKueue.dispatcherName` in the Kueue configuration. Available since Kueue v0.13.
+
+| Strategy | Name | Behaviour |
+|---|---|---|
+| **AllAtOnce** (default) | `kueue.x-k8s.io/multikueue-dispatcher-all-at-once` | Nominates **every** cluster in the MultiKueueConfig at once, creates a remote Workload on each, **first to admit wins**, the rest are deleted |
+| **Incremental** | `kueue.x-k8s.io/multikueue-dispatcher-incremental` | Nominates in waves of `stepSize` (default 3). If nobody admits within 5 minutes, the next wave is added, until admitted or all clusters are nominated |
+| **Custom** | any controller name | Kueue only manages the remote copies; your controller picks the target clusters |
+
+### What this demo uses
+
+**AllAtOnce**, stated explicitly in `manifests/kueue-config.yaml`:
+
+```yaml
+multiKueue:
+  dispatcherName: kueue.x-k8s.io/multikueue-dispatcher-all-at-once
+  # only honoured by the incremental dispatcher:
+  # incrementalDispatcherConfig:
+  #   stepSize: 1
+  workerLostTimeout: 15m
+  gcInterval: 1m
+```
+
+With only 2 workers, AllAtOnce and Incremental (default stepSize 3) behave identically.
+It is written out to make the knob visible and easy to change.
+
+### Choosing between them
+
+- **AllAtOnce** — fastest start (all clusters compete simultaneously), at the cost of
+  briefly creating a remote object on N clusters. Use it for small fleets.
+- **Incremental** — gentler at scale, avoiding a burst of objects across dozens of clusters.
+  And since v0.19, the `MultiKueueIncrementalDispatcherRespectConfigOrder` gate (beta, on
+  by default) makes waves follow the order in `MultiKueueConfig.spec.clusters` — which
+  effectively **turns that list into a preference list**, enabling policies like "prefer
+  the on-prem cluster, overflow to cloud".
+
+### Observing dispatch
+
+```bash
+# clusters currently nominated, decision still open
+kubectl --context kind-mk-manager -n default get workloads \
+  -o custom-columns='WL:.metadata.name,NOMINATED:.status.nominatedClusterNames'
+
+# the winner (immutable once set; nominatedClusterNames is cleared)
+kubectl --context kind-mk-manager -n default get workloads \
+  -o custom-columns='WL:.metadata.name,WINNER:.status.clusterName'
+```
+
+---
+
+## 6. Layout
+
+```
+multikueue-minimal-demo/
+├── README.md                       # this file — architecture (English)
+├── README.zh-CN.md                 # architecture (Chinese)
+├── WALKTHROUGH.md                  # step-by-step commands + real output (English)
+├── WALKTHROUGH.zh-CN.md            # step-by-step commands + real output (Chinese)
+├── manifests/
+│   ├── kueue-config.yaml           # Kueue config: integrations + dispatch strategy
+│   ├── worker-queues.yaml          # worker-side queues (applied to every worker)
+│   ├── worker-multikueue-rbac.yaml # worker-side SA/RBAC the manager authenticates as
+│   └── manager-multikueue.yaml     # manager-side queues + MultiKueue wiring
+├── examples/
+│   ├── jobs.yaml                   # example 1: three batch/v1 Jobs
+│   ├── jobset.yaml                 # example 2: JobSet
+│   └── rayjob.yaml                 # example 3: RayJob
+└── scripts/
+    ├── common.sh                   # versions, cluster names, shared helpers
+    ├── 0-create-clusters.sh        # create the 3 kind clusters
+    ├── 1-install-frameworks.sh     # JobSet + KubeRay (MUST run before Kueue)
+    ├── 2-install-kueue.sh          # Kueue + configuration
+    ├── 3-setup-workers.sh          # worker queues
+    ├── 4-connect.sh                # build kubeconfigs, store as manager Secrets
+    ├── 5-setup-manager.sh          # manager MultiKueue wiring
+    ├── run-demo-job.sh             # example 1
+    ├── run-demo-jobset.sh          # example 2
+    ├── run-demo-rayjob.sh          # example 3
+    ├── clean-workloads.sh          # wipe all demo workloads
+    ├── ctx.sh                      # switch kubectl context between the 3 clusters
+    ├── status.sh                   # "submitted where vs. running where"
+    ├── up.sh                       # steps 0–5 in one go
+    └── down.sh                     # delete the clusters
+```
+
+---
+
+## 7. Quick start
+
+```bash
+cd multikueue-minimal-demo
+
+./scripts/up.sh                  # build the environment (~8–12 min)
+
+./scripts/run-demo-job.sh        # example 1: batch/Job
+./scripts/run-demo-jobset.sh     # example 2: JobSet
+./scripts/run-demo-rayjob.sh     # example 3: RayJob
+
+./scripts/status.sh              # check state at any time
+./scripts/down.sh                # tear down
+```
+
+Different Kueue version (v0.16.4 also supports MultiKueue and already uses the v1beta2 API):
+
+```bash
+KUEUE_VERSION=v0.16.4 JOBSET_VERSION=v0.10.1 KUBERAY_VERSION=1.5.1 ./scripts/up.sh
+```
+
+---
+
+## 8. When you actually do need OCM or a similar platform
+
+This demo proves MultiKueue needs no multi-cluster management platform. These cases,
+however, are where bare MultiKueue is genuinely not enough:
+
+| Scenario | Bare MultiKueue | Needs an external platform |
+|---|---|---|
+| Workers behind a firewall/NAT; the manager has no routable API server address | ✗ push model, does not work | ✓ OCM is pull model |
+| Registering and rotating credentials for dozens or hundreds of clusters | ✗ manual SA + Secret does not scale | ✓ automatic registration and sync |
+| Dynamic placement based on cluster labels/capabilities | ✗ MultiKueueConfig is a static list | ✓ placement policies |
+| A handful of clusters with routable networking | ✓ sufficient | unnecessary |
+
+The middle ground is `MultiKueueClusterProfile` (alpha, Kueue v0.15), which sources
+credentials from the standard [Cluster Inventory API](https://multicluster.sigs.k8s.io/)
+`ClusterProfile` object — vendor-neutral, producible by OCM, or created by hand.

--- a/kueue/multikueue-minimal-demo/README.zh-CN.md
+++ b/kueue/multikueue-minimal-demo/README.zh-CN.md
@@ -1,0 +1,371 @@
+# MultiKueue 最小化 Demo
+
+> English: [README.md](README.md) · 分步操作手册：[WALKTHROUGH.zh-CN.md](WALKTHROUGH.zh-CN.md)
+
+用 **kind + Kueue + JobSet + KubeRay** 四个组件，在本地搭出一套跨 3 个 Kubernetes 集群的
+MultiKueue 环境，并跑通 **batch/Job、JobSet、RayJob** 三种工作负载的跨集群分发。
+
+**不需要 OCM、Karmada、ArgoCD 或任何多集群管理平台。** MultiKueue 本身就是完整的多集群
+调度方案，集群之间的连接就是一份 kubeconfig。
+
+---
+
+## 1. 组件清单
+
+装在**每一个**集群上（manager 和 worker 都装）：
+
+| 组件 | 版本 | 作用 | 是否必需 |
+|---|---|---|---|
+| kind | v0.31.0 | 创建本地 k8s 集群 | 必需 |
+| Kubernetes | v1.35.0 | 节点镜像 | 必需（≥ 1.32） |
+| **Kueue** | v0.19.1 | 队列 / 配额 / MultiKueue 调度 | **必需** |
+| JobSet | v0.12.0 | JobSet 工作负载类型 | 只跑 batch/Job 时可省 |
+| KubeRay | v1.6.2 | RayJob / RayCluster 工作负载类型 | 只跑 batch/Job 时可省 |
+
+版本不是随便选的：Kueue v0.19.1 的 `go.mod` 里锁定的就是 jobset v0.12.0 和 kuberay v1.6.2，
+这三个版本是上游 e2e 验证过能配合工作的组合。
+
+`k8s ≥ 1.32` 这个下限来自 `JobManagedBy` 特性门控 —— MultiKueue 靠给 Job 打
+`spec.managedBy` 来让 manager 上的原生 Job 控制器"别插手"，1.32 起该门控默认开启。
+
+---
+
+## 2. 架构图
+
+```
+┌────────────────────────────────────────────────────────────────────────────┐
+│  MANAGER 集群   (kind: mk-manager)                    业务 Pod 数量：0      │
+│                                                                             │
+│    kubectl apply  Job / JobSet / RayJob   (标签: kueue.x-k8s.io/queue-name) │
+│                              │                                              │
+│                              ▼                                              │
+│    ┌──────────────────────────────────────────────────────────────────┐    │
+│    │  LocalQueue        user-queue                                     │    │
+│    │       │                                                           │    │
+│    │       ▼                                                           │    │
+│    │  ClusterQueue      cluster-queue          配额: 10 CPU / 20Gi     │    │
+│    │       │                                   (闸门①  —— 分发节流)    │    │
+│    │       │  admissionChecksStrategy                                  │    │
+│    │       ▼                                                           │    │
+│    │  AdmissionCheck    multikueue-check                               │    │
+│    │       │            controllerName: kueue.x-k8s.io/multikueue      │    │
+│    │       │  parameters                                               │    │
+│    │       ▼                                                           │    │
+│    │  MultiKueueConfig  multikueue-config                              │    │
+│    │       │            clusters: [ mk-worker1, mk-worker2 ]           │    │
+│    │       ├───────────────────────────┬───────────────────────────┐   │    │
+│    │       ▼                           ▼                           │   │    │
+│    │  MultiKueueCluster           MultiKueueCluster                │   │    │
+│    │    mk-worker1                  mk-worker2                     │   │    │
+│    │       │ kubeConfig                │ kubeConfig                 │   │    │
+│    │       ▼ locationType: Secret      ▼                            │   │    │
+│    │  Secret                       Secret                          │   │    │
+│    │    mk-worker1-secret            mk-worker2-secret             │   │    │
+│    └───────┼───────────────────────────┼───────────────────────────────┘    │
+└────────────┼───────────────────────────┼────────────────────────────────────┘
+             │                           │
+             │  ServiceAccount token     │  ServiceAccount token
+             │  https://172.19.0.3:6443  │  https://172.19.0.4:6443
+             │  (docker "kind" 网络内)    │
+             ▼                           ▼
+┌───────────────────────────────┐ ┌───────────────────────────────┐
+│ WORKER 集群      mk-worker1   │ │ WORKER 集群      mk-worker2   │
+│                               │ │                               │
+│  LocalQueue    user-queue     │ │  LocalQueue    user-queue     │ ← 名字必须
+│       │                       │ │       │                       │   和 manager
+│       ▼                       │ │       ▼                       │   完全一致
+│  ClusterQueue  cluster-queue  │ │  ClusterQueue  cluster-queue  │
+│       配额: 2 CPU / 4Gi       │ │       配额: 2 CPU / 4Gi       │ ← 闸门②
+│       (真正的准入决策)         │ │       (真正的准入决策)         │   物理容量
+│                               │ │                               │
+│  ▶▶ Pod 真正在这里运行         │ │  ▶▶ Pod 真正在这里运行         │
+└───────────────────────────────┘ └───────────────────────────────┘
+```
+
+### 三条必须记住的规则
+
+1. **worker 上的 namespace 和 LocalQueue 名字必须和 manager 完全一致。**
+   MultiKueue 把 Workload 原样复制到 worker，找不到同名 LocalQueue 就卡住。
+
+2. **`integrations.frameworks` 必须和 worker 上实际装的 operator 一致。**
+   manager 会为每个启用的框架在 worker 上建 watch，缺 CRD 就整个连接失败。这是本 demo
+   踩到的第一个坑，见 [WALKTHROUGH 排错](WALKTHROUGH.zh-CN.md#坑1-jobset-crd-缺失导致连接失败)。
+
+3. **manager 上永远不会有业务 Pod。** 这是验证 MultiKueue 是否真的生效的最直接标志。
+
+---
+
+## 3. 工作流程图
+
+```
+  用户                 MANAGER 集群                   WORKER w1        WORKER w2
+   │                       │                            │                │
+   │ ① kubectl apply job   │                            │                │
+   │   (带 queue-name 标签) │                            │                │
+   ├──────────────────────>│                            │                │
+   │                       │                            │                │
+   │            ┌──────────┴──────────┐                 │                │
+   │            │ ② Kueue webhook 拦截 │                 │                │
+   │            │   suspend = true    │                 │                │
+   │            │   managedBy =       │                 │                │
+   │            │   .../multikueue    │                 │                │
+   │            └──────────┬──────────┘                 │                │
+   │                       │  原生 Job 控制器发现        │                │
+   │                       │  managedBy 不是自己         │                │
+   │                       │  → 完全不碰                 │                │
+   │                       │                            │                │
+   │            ┌──────────┴──────────┐                 │                │
+   │            │ ③ 创建 Workload      │                 │                │
+   │            │   闸门①: manager     │                 │                │
+   │            │   ClusterQueue 配额  │                 │                │
+   │            │   → QuotaReserved   │                 │                │
+   │            └──────────┬──────────┘                 │                │
+   │                       │                            │                │
+   │            ┌──────────┴──────────┐                 │                │
+   │            │ ④ AdmissionCheck    │                 │                │
+   │            │   触发 dispatcher    │                 │                │
+   │            │   AllAtOnce → 两个都提名               │                │
+   │            │ status.nominated    │                 │                │
+   │            │   ClusterNames      │                 │                │
+   │            └──────────┬──────────┘                 │                │
+   │                       │                            │                │
+   │                       │ ⑤ 在候选 worker 上各建一份远程 Workload      │
+   │                       ├───────────────────────────>│                │
+   │                       ├────────────────────────────────────────────>│
+   │                       │                            │                │
+   │                       │        ⑥ 闸门②: worker ClusterQueue 配额     │
+   │                       │           w1 先 admit      │                │
+   │                       │<───────────────────────────┤                │
+   │                       │                            │                │
+   │            ┌──────────┴──────────┐                 │                │
+   │            │ ⑦ w1 胜出:           │                 │                │
+   │            │  • 删掉 w2 上的副本  ─┼─────────────────┼───────────────>│ ✗
+   │            │  • status.cluster   │                 │                │
+   │            │    Name = w1        │                 │                │
+   │            │    (从此不可变)      │                 │                │
+   │            └──────────┬──────────┘                 │                │
+   │                       │                            │                │
+   │                       │ ⑧ 在 w1 上创建真正的 Job    │                │
+   │                       │   打 prebuilt-workload-name 标签关联         │
+   │                       ├───────────────────────────>│                │
+   │                       │                            │                │
+   │                       │           ⑨ w1 上的 Job 控制器 unsuspend     │
+   │                       │              → Pod 在这里跑 ◀◀              │
+   │                       │                            │                │
+   │                       │ ⑩ 持续状态同步              │                │
+   │                       │<══════════════════════════>│                │
+   │                       │                            │                │
+   │ kubectl get job       │                            │                │
+   │<──────────────────────┤  看到的是 w1 上的真实执行结果                 │
+   │                       │                            │                │
+   │                       │ ⑪ Workload Finished → 最后一次同步，          │
+   │                       │    然后删除 w1 上的远程对象                   │
+   │                       ├───────────────────────────>│ ✗              │
+```
+
+### 实际观测到的 Workload 状态
+
+```yaml
+status:
+  clusterName: mk-worker2            # ← 最终跑在哪个集群（一旦设置就不可变）
+  admissionChecks:
+  - name: multikueue-check
+    state: Ready
+    message: The workload was admitted on "mk-worker2"
+  conditions:
+  - type: QuotaReserved              # ← 闸门①：manager 配额通过
+    status: "True"
+    message: Quota reserved in ClusterQueue cluster-queue
+  - type: Admitted                   # ← 闸门②：worker 接了单
+    status: "True"
+  - type: PodsReady
+    status: "True"
+```
+
+---
+
+## 4. 配额是怎么执行的（Quota Enforcement）
+
+这是 MultiKueue 最容易搞混的地方：**配额有两级，而且两级的含义完全不同。**
+
+### 第一级：manager ClusterQueue —— 分发节流阀，不是执行闸门
+
+manager 的配额决定"**同一时刻最多允许多少 Workload 进入分发流程**"。Workload 必须
+先在 manager 拿到 `QuotaReserved`，MultiKueue 的 AdmissionCheck 才会被触发。
+
+注意 manager 这一级配额是**虚账**：manager 上没有任何 Pod 真正消耗资源，它只是一个准入
+节流阀。
+
+### 第二级：worker ClusterQueue —— 真正的执行闸门
+
+worker 的配额是**实账**，直接对应该集群的物理容量。Workload 副本要在 worker 的
+ClusterQueue 里走一遍完整的标准 Kueue 准入（配额、ResourceFlavor 匹配、借用、抢占……）。
+worker 拒绝，就没人跑。
+
+### 两级配额怎么配
+
+上游文档给的原则是：**manager 配额 ≈ 所有 worker 配额之和**。
+
+| 配置 | 后果 |
+|---|---|
+| manager 配额 **远小于** worker 总和 | worker 集群闲置 —— manager 卡着不放行 |
+| manager 配额 **远大于** worker 总和 | manager 分发出一大堆没人接得住的 Workload，白白建远程对象、白白监控 |
+| manager 配额 ≈ worker 总和 | 合理 |
+
+本 demo 故意**没有**遵守这条原则：manager 给了 10 CPU，两个 worker 各 2 CPU（总和 4 CPU）。
+这是刻意的教学设置 —— 让 manager 不构成瓶颈，把配额压力全压到 worker 上，这样才能清楚看到
+**是 worker 在真正做准入决策**。
+
+### 实际观测
+
+提交 3 个各要 2 CPU 的 Job：
+
+```
+MANAGER — Workloads
+WORKLOAD               ADMITTED   DISPATCHED-TO
+job-demo-job-1-a9067   <none>     <none>          ← 两个 worker 都满了，等着
+job-demo-job-2-dd6ff   True       mk-worker2
+job-demo-job-3-53d6e   True       mk-worker1
+
+WORKER mk-worker1: cluster-queue   PENDING 1   ADMITTED 1
+WORKER mk-worker2: cluster-queue   PENDING 1   ADMITTED 1
+```
+
+读法：manager 的 10 CPU 配额足够 3 个 Job 全部 `QuotaReserved`，所以 3 份副本都被分发到了
+两个 worker（`PENDING 1` 就是那个没抢到的副本在排队）。但 worker 各只有 2 CPU，各自只能
+admit 一个。第三个 Job 就一直挂着 —— **决定权在 worker，不在 manager**。
+
+### 相关的进阶特性
+
+- `MultiKueueManagerQuotaAutomation`（v0.18 引入，alpha，默认关闭）：让 manager 自动从
+  worker 汇总配额，省掉手工对齐两级配额的麻烦。
+- worker 上的 `ResourceFlavor` 名字要和 manager 对得上，否则 Workload 复制过去会因为
+  找不到 flavor 而无法准入。本 demo 两边都叫 `default-flavor`。
+
+---
+
+## 5. 分发策略（Dispatch Strategy）
+
+MultiKueue 决定"把 Workload 发给哪些 worker"的逻辑叫 **dispatcher**，在 Kueue 配置的
+`multiKueue.dispatcherName` 字段里配。Kueue v0.13 起提供该机制。
+
+| 策略 | 名称 | 行为 |
+|---|---|---|
+| **AllAtOnce**（默认） | `kueue.x-k8s.io/multikueue-dispatcher-all-at-once` | 一次性提名 MultiKueueConfig 里**所有** worker，每个都建一份远程 Workload，**谁先 admit 谁赢**，其余副本删掉 |
+| **Incremental** | `kueue.x-k8s.io/multikueue-dispatcher-incremental` | 分批提名，每批 `stepSize` 个（默认 3）。若 5 分钟内无人接，再放下一批，直到被接或全部提名完 |
+| **自定义** | 任意控制器名 | Kueue 只负责管远程副本，由你的控制器决定选哪些集群 |
+
+### 本 demo 用的策略
+
+显式配置为 **AllAtOnce**，写在 `manifests/kueue-config.yaml`：
+
+```yaml
+multiKueue:
+  dispatcherName: kueue.x-k8s.io/multikueue-dispatcher-all-at-once
+  # 仅 incremental 策略生效：
+  # incrementalDispatcherConfig:
+  #   stepSize: 1
+  workerLostTimeout: 15m
+  gcInterval: 1m
+```
+
+只有 2 个 worker 时 AllAtOnce 和 Incremental（默认 stepSize=3）行为一致，写出来是为了让这个
+旋钮可见、可改。
+
+### 怎么选
+
+- **AllAtOnce**：启动最快（所有集群同时竞争），代价是瞬时会在 N 个集群上各建一份远程对象。
+  集群数少（个位数）时用它。
+- **Incremental**：集群规模大时更温和，避免一次性在几十个集群上建对象。而且从 v0.19 起
+  `MultiKueueIncrementalDispatcherRespectConfigOrder` 门控（beta，默认开启）让提名顺序
+  严格按 `MultiKueueConfig.spec.clusters` 的列表顺序走 —— **这等于把 clusters 列表变成了
+  优先级列表**，可以实现"优先本地集群，本地满了再溢出到云上"这类策略。
+
+### 观测分发过程
+
+```bash
+# 正在被提名、还没定下来的候选集群
+kubectl --context kind-mk-manager -n default get workloads \
+  -o custom-columns='WL:.metadata.name,NOMINATED:.status.nominatedClusterNames'
+
+# 最终花落谁家（一旦设置即不可变，nominatedClusterNames 同时被清空）
+kubectl --context kind-mk-manager -n default get workloads \
+  -o custom-columns='WL:.metadata.name,WINNER:.status.clusterName'
+```
+
+---
+
+## 6. 目录结构
+
+```
+multikueue-minimal-demo/
+├── README.md                       # 架构与原理（英文）
+├── README.zh-CN.md                 # 本文件：架构与原理（中文）
+├── WALKTHROUGH.md                  # 分步操作 + 每条命令的真实输出（英文）
+├── WALKTHROUGH.zh-CN.md            # 分步操作 + 每条命令的真实输出（中文）
+├── manifests/
+│   ├── kueue-config.yaml           # Kueue 配置：集成列表 + 分发策略
+│   ├── worker-queues.yaml          # worker 侧队列（每个 worker 都要）
+│   ├── worker-multikueue-rbac.yaml # worker 侧 SA/RBAC，manager 用它来操作 worker
+│   └── manager-multikueue.yaml     # manager 侧队列 + MultiKueue 接线
+├── examples/
+│   ├── jobs.yaml                   # 示例1：3 个 batch/v1 Job
+│   ├── jobset.yaml                 # 示例2：JobSet
+│   └── rayjob.yaml                 # 示例3：RayJob
+└── scripts/
+    ├── common.sh                   # 版本号、集群名、公共函数
+    ├── 0-create-clusters.sh        # 建 3 个 kind 集群
+    ├── 1-install-frameworks.sh     # 装 JobSet + KubeRay（必须在 Kueue 之前）
+    ├── 2-install-kueue.sh          # 装 Kueue + 应用配置
+    ├── 3-setup-workers.sh          # worker 队列
+    ├── 4-connect.sh                # 生成 kubeconfig 并存为 manager 上的 Secret
+    ├── 5-setup-manager.sh          # manager MultiKueue 接线
+    ├── run-demo-job.sh             # 示例1
+    ├── run-demo-jobset.sh          # 示例2
+    ├── run-demo-rayjob.sh          # 示例3
+    ├── clean-workloads.sh          # 清空所有 demo 负载
+    ├── ctx.sh                      # 在 3 个集群之间切换 kubectl context
+    ├── status.sh                   # 查看"提交在哪 vs 跑在哪"
+    ├── up.sh                       # 0~5 一把梭
+    └── down.sh                     # 删集群
+```
+
+---
+
+## 7. 快速开始
+
+```bash
+cd multikueue-minimal-demo
+
+./scripts/up.sh                  # 建环境（约 8~12 分钟）
+
+./scripts/run-demo-job.sh        # 示例1：batch/Job
+./scripts/run-demo-jobset.sh     # 示例2：JobSet
+./scripts/run-demo-rayjob.sh     # 示例3：RayJob
+
+./scripts/status.sh              # 随时查看状态
+./scripts/down.sh                # 清理
+```
+
+换 Kueue 版本（例如 v0.16.4，同样支持 MultiKueue 且已经是 v1beta2 API）：
+
+```bash
+KUEUE_VERSION=v0.16.4 JOBSET_VERSION=v0.10.1 KUBERAY_VERSION=1.5.1 ./scripts/up.sh
+```
+
+---
+
+## 8. 什么时候才真的需要 OCM 之类的多集群平台
+
+本 demo 证明了 MultiKueue 不依赖任何多集群管理平台。但下面这些场景，裸 MultiKueue 确实不够：
+
+| 场景 | 裸 MultiKueue | 需要外部平台 |
+|---|---|---|
+| worker 在防火墙 / NAT 后，manager 拿不到可路由的 API server 地址 | ✗ 走不通（push 模型） | ✓ OCM 是 pull 模型 |
+| 几十上百个集群的注册与凭证轮转 | ✗ 手工 SA + Secret，运维不可持续 | ✓ 自动注册与同步 |
+| 需要基于集群标签/能力做动态放置 | ✗ MultiKueueConfig 是静态列表 | ✓ Placement 策略 |
+| 几个集群、网络互通、手工可控 | ✓ 够用 | 不必要 |
+
+中间路线是 Kueue v0.15 引入的 `MultiKueueClusterProfile`（alpha），通过标准的
+[Cluster Inventory API](https://multicluster.sigs.k8s.io/) `ClusterProfile` 对象拿凭证 ——
+厂商中立，OCM 能生成，也可以手工创建。

--- a/kueue/multikueue-minimal-demo/WALKTHROUGH.md
+++ b/kueue/multikueue-minimal-demo/WALKTHROUGH.md
@@ -1,0 +1,1196 @@
+# MultiKueue Demo — Step-by-Step Walkthrough
+
+> 中文版：[WALKTHROUGH.zh-CN.md](WALKTHROUGH.zh-CN.md) · Architecture: [README.md](README.md)
+
+Every command below, and its **real output**, captured from an actual run on
+macOS / Apple Silicon / Docker Desktop.
+
+**Contents**
+
+- [Step 0: install the prerequisites](#step-0-install-the-prerequisites)
+- [Step 1: create the three kind clusters](#step-1-create-the-three-kind-clusters)
+- [Context switching](#context-switching)
+- [Step 2: install JobSet and KubeRay](#step-2-install-jobset-and-kuberay)
+- [Step 3: install Kueue and enable MultiKueue](#step-3-install-kueue-and-enable-multikueue)
+- [Step 4: configure the worker queues](#step-4-configure-the-worker-queues)
+- [Step 5: connect the manager to the workers](#step-5-connect-the-manager-to-the-workers)
+- [Step 6: wire up MultiKueue on the manager](#step-6-wire-up-multikueue-on-the-manager)
+- [Test 1: batch/v1 Job](#test-1-batchv1-job)
+- [Test 2: JobSet](#test-2-jobset)
+- [Test 3: RayJob](#test-3-rayjob)
+- [Troubleshooting](#troubleshooting)
+- [Cleanup](#cleanup)
+
+---
+
+## Step 0: install the prerequisites
+
+### 0.1 Docker
+
+Three kind clusters run side by side, so give Docker at least **8GB of memory**
+(12GB+ if you want the RayJob example). On macOS: Docker Desktop → Settings → Resources.
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % docker info --format '{{.MemTotal}} {{.NCPU}}'
+24898469888 14
+```
+
+### 0.2 kind
+
+Must be **≥ v0.31.0** (its default node image is k8s v1.35.0).
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % brew install kind
+```
+
+Other platforms:
+
+```console
+# Linux amd64
+gyliu-cary@Mac ~ % curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.31.0/kind-linux-amd64
+gyliu-cary@Mac ~ % chmod +x ./kind && sudo mv ./kind /usr/local/bin/kind
+
+# macOS Apple Silicon (without brew)
+gyliu-cary@Mac ~ % curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.31.0/kind-darwin-arm64
+gyliu-cary@Mac ~ % chmod +x ./kind && sudo mv ./kind /usr/local/bin/kind
+```
+
+Verify:
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kind version
+kind v0.31.0 go1.25.5 darwin/arm64
+```
+
+### 0.3 kubectl and helm
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % brew install kubectl helm
+```
+
+Verify:
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl version --client
+Client Version: v1.32.2
+Kustomize Version: v5.5.0
+```
+
+`helm` is used only for the KubeRay operator. Kueue and JobSet are installed by applying
+their official released `manifests.yaml` — no helm needed.
+
+---
+
+## Step 1: create the three kind clusters
+
+One manager, two workers, each a single-node cluster.
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % ./scripts/0-create-clusters.sh
+==> creating cluster mk-manager
+Creating cluster "mk-manager" ...
+ • Ensuring node image (kindest/node:v1.35.0) 🖼  ...
+ ✓ Ensuring node image (kindest/node:v1.35.0) 🖼
+ • Preparing nodes 📦   ...
+ ✓ Preparing nodes 📦
+ • Writing configuration 📜  ...
+ ✓ Writing configuration 📜
+ • Starting control-plane 🕹️  ...
+ ✓ Starting control-plane 🕹️
+ • Installing CNI 🔌  ...
+ ✓ Installing CNI 🔌
+ • Installing StorageClass 💾  ...
+ ✓ Installing StorageClass 💾
+ • Waiting ≤ 2m0s for control-plane = Ready ⏳  ...
+ ✓ Waiting ≤ 2m0s for control-plane = Ready ⏳
+ • Ready after 16s 💚
+Set kubectl context to "kind-mk-manager"
+
+==> creating cluster mk-worker1
+Creating cluster "mk-worker1" ...
+ ✓ Ready after 17s 💚
+Set kubectl context to "kind-mk-worker1"
+
+==> creating cluster mk-worker2
+Creating cluster "mk-worker2" ...
+ ✓ Ready after 16s 💚
+Set kubectl context to "kind-mk-worker2"
+
+==> clusters ready:
+mk-manager
+mk-worker1
+mk-worker2
+```
+
+Equivalent manual commands:
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kind create cluster --name mk-manager --image kindest/node:v1.35.0 --wait 120s
+gyliu-cary@Mac multikueue-minimal-demo % kind create cluster --name mk-worker1 --image kindest/node:v1.35.0 --wait 120s
+gyliu-cary@Mac multikueue-minimal-demo % kind create cluster --name mk-worker2 --image kindest/node:v1.35.0 --wait 120s
+```
+
+### Verify
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kind get clusters
+mk-manager
+mk-worker1
+mk-worker2
+```
+
+kind writes three contexts into your kubeconfig automatically:
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl config get-contexts | grep mk-
+*         kind-mk-manager   kind-mk-manager   kind-mk-manager
+          kind-mk-worker1   kind-mk-worker1   kind-mk-worker1
+          kind-mk-worker2   kind-mk-worker2   kind-mk-worker2
+```
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-manager get nodes
+NAME                       STATUS   ROLES           AGE   VERSION
+mk-manager-control-plane   Ready    control-plane   27m   v1.35.0
+```
+
+### Key point: all three clusters share one docker network
+
+kind puts every cluster on a bridge network called `kind`. **This is what makes the
+manager able to reach the worker API servers:**
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % docker network inspect kind -f '{{range .Containers}}{{.Name}} {{.IPv4Address}}{{"\n"}}{{end}}' | grep control-plane
+mk-manager-control-plane 172.19.0.2/16
+mk-worker1-control-plane 172.19.0.3/16
+mk-worker2-control-plane 172.19.0.4/16
+```
+
+Step 5 uses these IPs.
+
+---
+
+## Context switching
+
+This demo spans 3 clusters, and verifying it means constantly hopping between the manager
+and the workers to inspect pods. This section collects every way to do that.
+
+### The three context names
+
+kind writes contexts into `~/.kube/config` automatically, named `kind-<cluster>`:
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl config get-contexts | grep mk-
+*         kind-mk-manager   kind-mk-manager   kind-mk-manager
+          kind-mk-worker1   kind-mk-worker1   kind-mk-worker1
+          kind-mk-worker2   kind-mk-worker2   kind-mk-worker2
+```
+
+| Cluster | Context name | Role |
+|---|---|---|
+| mk-manager | `kind-mk-manager` | submit jobs, inspect dispatch results |
+| mk-worker1 | `kind-mk-worker1` | see the pods that actually run |
+| mk-worker2 | `kind-mk-worker2` | see the pods that actually run |
+
+### Option 1: `--context` per command (recommended)
+
+**Leaves your default context untouched** — the safest form, and what every command in this
+walkthrough uses:
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-manager -n default get workloads
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-worker1 -n default get pods
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-worker2 -n default get pods
+```
+
+The upside is that you can **compare clusters in a single command line**, with no risk of
+forgetting to switch back:
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % for c in manager worker1 worker2; do \
+  echo "--- $c"; kubectl --context kind-mk-$c -n default get pods --no-headers 2>&1; done
+--- manager
+No resources found in default namespace.
+--- worker1
+demo-job-3-lhjdn   1/1   Running   0   12s
+--- worker2
+demo-job-2-lhjct   1/1   Running   0   13s
+```
+
+That one command shows MultiKueue working at a glance: no pods on the manager, one on each
+worker.
+
+### Option 2: switch the default context
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl config use-context kind-mk-worker1
+Switched to context "kind-mk-worker1".
+```
+
+Check where you currently point:
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl config current-context
+kind-mk-worker1
+```
+
+Commands without `--context` now act on that cluster:
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl get nodes
+NAME                       STATUS   ROLES           AGE   VERSION
+mk-worker1-control-plane   Ready    control-plane   38m   v1.35.0
+```
+
+Switch back to the manager:
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl config use-context kind-mk-manager
+Switched to context "kind-mk-manager".
+```
+
+### Option 3: the demo's helper script
+
+`scripts/ctx.sh` wraps the above and accepts short forms:
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % ./scripts/ctx.sh
+==> demo contexts (* = current):
+  * kind-mk-manager
+    kind-mk-worker1
+    kind-mk-worker2
+
+usage: ./scripts/ctx.sh <manager|worker1|worker2>
+```
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % ./scripts/ctx.sh worker1
+Switched to context "kind-mk-worker1".
+==> now pointing at mk-worker1
+NAME                       STATUS   ROLES           AGE   VERSION
+mk-worker1-control-plane   Ready    control-plane   38m   v1.35.0
+```
+
+Accepted forms: `manager` / `mgr` / `m`, `worker1` / `w1` / `1`, `worker2` / `w2` / `2`.
+
+### Option 4: shell aliases (easiest while experimenting)
+
+Paste these into your shell (or into `~/.zshrc`):
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % alias kmgr='kubectl --context kind-mk-manager'
+gyliu-cary@Mac multikueue-minimal-demo % alias kw1='kubectl --context kind-mk-worker1'
+gyliu-cary@Mac multikueue-minimal-demo % alias kw2='kubectl --context kind-mk-worker2'
+```
+
+Then:
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kmgr -n default get workloads
+gyliu-cary@Mac multikueue-minimal-demo % kw1 -n default get pods
+gyliu-cary@Mac multikueue-minimal-demo % kw2 -n default get pods
+```
+
+### Option 5: kubectx (third-party)
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % brew install kubectx
+gyliu-cary@Mac multikueue-minimal-demo % kubectx kind-mk-worker1
+gyliu-cary@Mac multikueue-minimal-demo % kubectx -          # back to the previous context
+```
+
+### Quick reference
+
+| What you want to see | Which cluster | Command |
+|---|---|---|
+| Submitted Job/JobSet/RayJob | manager | `kubectl --context kind-mk-manager -n default get jobs,jobsets,rayjobs` |
+| Where a Workload was dispatched | manager | `kubectl --context kind-mk-manager -n default get workloads -o custom-columns='WL:.metadata.name,RAN-ON:.status.clusterName'` |
+| MultiKueue connection health | manager | `kubectl --context kind-mk-manager get multikueuecluster` |
+| **The pods that actually run** | worker | `kubectl --context kind-mk-worker1 -n default get pods` |
+| Worker quota usage | worker | `kubectl --context kind-mk-worker1 get clusterqueue cluster-queue` |
+| Kueue controller logs | manager | `kubectl --context kind-mk-manager -n kueue-system logs deployment/kueue-controller-manager` |
+
+> `./scripts/status.sh` walks all three clusters and prints all of the above at once, so you
+> do not have to switch manually.
+
+---
+
+## Step 2: install JobSet and KubeRay
+
+**This must happen before installing Kueue.** Kueue decides which integrations to enable
+at startup based on which CRDs exist; CRDs installed afterwards are not picked up.
+
+All three clusters get them, **including the manager**. Reason: MultiKueue keeps a "shadow"
+copy of the JobSet/RayJob on the manager. Both operators honour
+`spec.managedBy=kueue.x-k8s.io/multikueue` and deliberately do nothing when they see it, so
+no pods are created on the manager. (Requires JobSet ≥ v0.6.0 and KubeRay ≥ v1.3.1.)
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % ./scripts/1-install-frameworks.sh
+==> adding the kuberay helm repo
+==> installing JobSet v0.12.0 on mk-manager
+==> installing KubeRay 1.6.2 on mk-manager
+Release "kuberay-operator" does not exist. Installing it now.
+NAME: kuberay-operator
+LAST DEPLOYED: Fri Aug 14 10:44:19 2026
+NAMESPACE: kuberay-system
+STATUS: deployed
+REVISION: 1
+
+==> installing JobSet v0.12.0 on mk-worker1
+==> installing KubeRay 1.6.2 on mk-worker1
+...
+==> waiting for the JobSet controller on mk-manager
+deployment "jobset-controller-manager" successfully rolled out
+==> waiting for the JobSet controller on mk-worker1
+deployment "jobset-controller-manager" successfully rolled out
+==> waiting for the JobSet controller on mk-worker2
+deployment "jobset-controller-manager" successfully rolled out
+
+==> framework CRDs now available:
+--- mk-manager
+jobsets.jobset.x-k8s.io
+rayjobs.ray.io
+rayclusters.ray.io
+rayservices.ray.io
+--- mk-worker1
+jobsets.jobset.x-k8s.io
+rayjobs.ray.io
+rayclusters.ray.io
+rayservices.ray.io
+--- mk-worker2
+jobsets.jobset.x-k8s.io
+rayjobs.ray.io
+rayclusters.ray.io
+rayservices.ray.io
+```
+
+Equivalent manual commands (repeat per context):
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-manager apply --server-side \
+  -f https://github.com/kubernetes-sigs/jobset/releases/download/v0.12.0/manifests.yaml
+
+gyliu-cary@Mac multikueue-minimal-demo % helm repo add kuberay https://ray-project.github.io/kuberay-helm/
+gyliu-cary@Mac multikueue-minimal-demo % helm --kube-context kind-mk-manager upgrade --install kuberay-operator \
+  kuberay/kuberay-operator --version 1.6.2 -n kuberay-system --create-namespace --wait
+```
+
+### Verify
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-manager get pods -A | grep -E "jobset|kuberay"
+jobset-system        jobset-controller-manager-5585d4c665-c9qf4         1/1     Running   0          14m
+kuberay-system       kuberay-operator-5dff8cd9d5-wz9nm                  1/1     Running   0          14m
+```
+
+---
+
+## Step 3: install Kueue and enable MultiKueue
+
+### 3.1 Does MultiKueue need to be turned on?
+
+**No.** The `MultiKueue` feature gate has been **Beta and enabled by default since Kueue
+v0.9**:
+
+```go
+// pkg/features/kube_features.go
+MultiKueue: {
+    {Version: version.MustParse("0.6"), Default: false, PreRelease: featuregate.Alpha},
+    {Version: version.MustParse("0.9"), Default: true,  PreRelease: featuregate.Beta},
+},
+```
+
+So installing Kueue is enough — no `--feature-gates` flag required. What actually *activates*
+MultiKueue is creating the CRs in step 6 (AdmissionCheck / MultiKueueConfig / MultiKueueCluster).
+
+### 3.2 Install
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % ./scripts/2-install-kueue.sh
+==> installing Kueue v0.19.1 on mk-manager
+==> pinning enabled integrations on mk-manager
+configmap/kueue-manager-config configured
+deployment.apps/kueue-controller-manager restarted
+==> installing Kueue v0.19.1 on mk-worker1
+==> pinning enabled integrations on mk-worker1
+configmap/kueue-manager-config configured
+deployment.apps/kueue-controller-manager restarted
+==> installing Kueue v0.19.1 on mk-worker2
+==> pinning enabled integrations on mk-worker2
+configmap/kueue-manager-config configured
+deployment.apps/kueue-controller-manager restarted
+==> waiting for kueue-controller-manager on mk-manager
+deployment "kueue-controller-manager" successfully rolled out
+==> waiting for kueue-controller-manager on mk-worker1
+deployment "kueue-controller-manager" successfully rolled out
+==> waiting for kueue-controller-manager on mk-worker2
+deployment "kueue-controller-manager" successfully rolled out
+==> enabled integrations (should list batch/job, jobset and the ray kinds):
+integrations:
+  frameworks:
+  - "batch/job"
+  - "jobset.x-k8s.io/jobset"
+  - "ray.io/rayjob"
+  - "ray.io/raycluster"
+  - "ray.io/rayservice"
+```
+
+Equivalent manual commands:
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-manager apply --server-side \
+  -f https://github.com/kubernetes-sigs/kueue/releases/download/v0.19.1/manifests.yaml
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-manager apply -f manifests/kueue-config.yaml
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-manager -n kueue-system rollout restart deployment/kueue-controller-manager
+```
+
+### 3.3 Why the ConfigMap must be edited
+
+This is the most important gotcha in the whole demo. Kueue enables a long list of
+integrations out of the box:
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-manager -n kueue-system get cm kueue-manager-config \
+  -o jsonpath='{.data.controller_manager_config\.yaml}' | grep -A 20 "^integrations:"
+integrations:
+  frameworks:
+  - "batch/job"
+  - "kubeflow.org/mpijob"
+  - "ray.io/rayjob"
+  - "ray.io/raycluster"
+  - "ray.io/rayservice"
+  - "jobset.x-k8s.io/jobset"
+  - "workload.codeflare.dev/appwrapper"
+  - "trainer.kubeflow.org/trainjob"
+  - "pod"
+  - "deployment"
+  - "statefulset"
+  - "leaderworkerset.x-k8s.io/leaderworkerset"
+```
+
+MultiKueue opens a watch **per enabled framework** on every worker. The workers have no
+AppWrapper / Kubeflow Trainer / LeaderWorkerSet CRDs, so those watches fail and the entire
+cluster connection is marked failed. `manifests/kueue-config.yaml` narrows the list to what
+this demo actually installs.
+
+**Rule: `integrations.frameworks` must correspond exactly to the operators installed on the
+workers.**
+
+### 3.4 The dispatch strategy lives in the same ConfigMap
+
+```yaml
+multiKueue:
+  dispatcherName: kueue.x-k8s.io/multikueue-dispatcher-all-at-once
+  workerLostTimeout: 15m
+  gcInterval: 1m
+```
+
+Full explanation in [README section 5](README.md#5-dispatch-strategy).
+
+### Verify
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-manager -n kueue-system get pods
+NAME                                        READY   STATUS    RESTARTS   AGE
+kueue-controller-manager-5cb5c9fbcd-mt4h2   1/1     Running   0          9m54s
+```
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-worker1 get crd | grep -E "jobset|ray.io|kueue"
+admissionchecks.kueue.x-k8s.io              2026-08-14T14:32:18Z
+clusterqueues.kueue.x-k8s.io                2026-08-14T14:32:18Z
+cohorts.kueue.x-k8s.io                      2026-08-14T14:32:18Z
+jobsets.jobset.x-k8s.io                     2026-08-14T14:44:18Z
+localqueues.kueue.x-k8s.io                  2026-08-14T14:32:18Z
+multikueueclusters.kueue.x-k8s.io           2026-08-14T14:32:18Z
+multikueueconfigs.kueue.x-k8s.io            2026-08-14T14:32:18Z
+provisioningrequestconfigs.kueue.x-k8s.io   2026-08-14T14:32:18Z
+rayclusters.ray.io                          2026-08-14T14:44:18Z
+raycronjobs.ray.io                          2026-08-14T14:44:18Z
+rayjobs.ray.io                              2026-08-14T14:44:18Z
+rayservices.ray.io                          2026-08-14T14:44:18Z
+```
+
+---
+
+## Step 4: configure the worker queues
+
+A worker cluster is just an ordinary standalone Kueue cluster. The key constraint:
+**the namespace and LocalQueue names must match the manager exactly** (here `default` /
+`user-queue`), because MultiKueue copies the Workload verbatim.
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % ./scripts/3-setup-workers.sh
+==> applying queues on mk-worker1
+resourceflavor.kueue.x-k8s.io/default-flavor created
+clusterqueue.kueue.x-k8s.io/cluster-queue created
+localqueue.kueue.x-k8s.io/user-queue created
+==> applying queues on mk-worker2
+resourceflavor.kueue.x-k8s.io/default-flavor created
+clusterqueue.kueue.x-k8s.io/cluster-queue created
+localqueue.kueue.x-k8s.io/user-queue created
+==> worker queues:
+--- mk-worker1
+NAME                                        COHORT   PENDING WORKLOADS
+clusterqueue.kueue.x-k8s.io/cluster-queue            0
+
+NAMESPACE   NAME                                   CLUSTERQUEUE    PENDING WORKLOADS   ADMITTED WORKLOADS
+default     localqueue.kueue.x-k8s.io/user-queue   cluster-queue   0                   0
+--- mk-worker2
+NAME                                        COHORT   PENDING WORKLOADS
+clusterqueue.kueue.x-k8s.io/cluster-queue            0
+
+NAMESPACE   NAME                                   CLUSTERQUEUE    PENDING WORKLOADS   ADMITTED WORKLOADS
+default     localqueue.kueue.x-k8s.io/user-queue   cluster-queue   0                   0
+```
+
+The worker quota is deliberately small (2 CPU / 4Gi) so the demo can show quota pressure
+landing on the worker side:
+
+```yaml
+# manifests/worker-queues.yaml
+resources:
+  - name: cpu
+    nominalQuota: 2
+  - name: memory
+    nominalQuota: 4Gi
+```
+
+---
+
+## Step 5: connect the manager to the workers
+
+This is the **only** cross-cluster mechanism: a kubeconfig, stored as a Secret on the manager.
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % ./scripts/4-connect.sh
+==> creating MultiKueue ServiceAccount on mk-worker1
+serviceaccount/multikueue-sa created
+clusterrole.rbac.authorization.k8s.io/multikueue-sa-role created
+clusterrolebinding.rbac.authorization.k8s.io/multikueue-sa-crb created
+secret/multikueue-sa created
+==> waiting for the ServiceAccount token to be populated on mk-worker1
+==> mk-worker1 API server reachable in-network at https://172.19.0.3:6443
+==> storing mk-worker1 kubeconfig as a Secret on mk-manager
+secret/mk-worker1-secret created
+==> creating MultiKueue ServiceAccount on mk-worker2
+serviceaccount/multikueue-sa created
+clusterrole.rbac.authorization.k8s.io/multikueue-sa-role created
+clusterrolebinding.rbac.authorization.k8s.io/multikueue-sa-crb created
+secret/multikueue-sa created
+==> waiting for the ServiceAccount token to be populated on mk-worker2
+==> mk-worker2 API server reachable in-network at https://172.19.0.4:6443
+==> storing mk-worker2 kubeconfig as a Secret on mk-manager
+secret/mk-worker2-secret created
+==> connection secrets on the manager:
+mk-worker1-secret           Opaque   1      0s
+mk-worker2-secret           Opaque   1      0s
+```
+
+Three things happen here:
+
+**1) Create a restricted ServiceAccount on the worker** (`manifests/worker-multikueue-rbac.yaml`).
+Permissions cover Kueue Workloads plus the three frameworks this demo installs. Note that
+this ClusterRole must cover **every** framework listed in `integrations.frameworks` from
+step 3, or the manager's watch gets a 403.
+
+**2) Request a long-lived token for that SA.** Since k8s 1.24, token Secrets are no longer
+created automatically, so it must be declared explicitly:
+
+```yaml
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/service-account-token
+metadata:
+  name: multikueue-sa
+  namespace: kueue-system
+  annotations:
+    kubernetes.io/service-account.name: multikueue-sa
+```
+
+**3) Assemble the kubeconfig, minding the server address** ← **the biggest kind gotcha**
+
+`kind get kubeconfig` gives you `https://127.0.0.1:<random-port>`, which **only works from
+the host**. The Kueue pod on the manager runs inside the container network and cannot reach
+it. You need the worker control-plane container's IP on the `kind` docker network:
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % docker inspect -f '{{.NetworkSettings.Networks.kind.IPAddress}}' mk-worker1-control-plane
+172.19.0.3
+```
+
+kubeadm puts that IP into the API server's serving certificate SANs, so TLS still verifies —
+no `insecure-skip-tls-verify` needed.
+
+The generated kubeconfig looks like this (token truncated):
+
+```yaml
+apiVersion: v1
+kind: Config
+clusters:
+  - name: mk-worker1
+    cluster:
+      certificate-authority-data: LS0tLS1CRUdJTiBDRVJU...
+      server: https://172.19.0.3:6443     # ← in-network address, NOT 127.0.0.1
+users:
+  - name: multikueue-sa
+    user:
+      token: eyJhbGciOiJSUzI1NiIsImtpZCI6...
+contexts:
+  - name: mk-worker1
+    context:
+      cluster: mk-worker1
+      user: multikueue-sa
+current-context: mk-worker1
+```
+
+### Verify
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-manager -n kueue-system get secret | grep -- -secret
+mk-worker1-secret           Opaque   1      12m
+mk-worker2-secret           Opaque   1      12m
+```
+
+---
+
+## Step 6: wire up MultiKueue on the manager
+
+Create the object chain:
+`ClusterQueue → AdmissionCheck → MultiKueueConfig → MultiKueueCluster → Secret`.
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % ./scripts/5-setup-manager.sh
+==> applying MultiKueue setup on mk-manager
+resourceflavor.kueue.x-k8s.io/default-flavor created
+clusterqueue.kueue.x-k8s.io/cluster-queue created
+localqueue.kueue.x-k8s.io/user-queue created
+admissioncheck.kueue.x-k8s.io/multikueue-check created
+multikueueconfig.kueue.x-k8s.io/multikueue-config created
+multikueuecluster.kueue.x-k8s.io/mk-worker1 created
+multikueuecluster.kueue.x-k8s.io/mk-worker2 created
+==> waiting for both MultiKueueClusters to report Active
+CLUSTER      ACTIVE   REASON   MESSAGE
+mk-worker1   True     Active   Connected
+mk-worker2   True     Active   Connected
+
+CHECK              ACTIVE   MESSAGE
+multikueue-check   True     The admission check is active
+```
+
+**`Active=True / Connected` means the environment is ready.**
+
+The critical piece is attaching the AdmissionCheck to the ClusterQueue — the only difference
+between an ordinary queue and a cross-cluster dispatching queue:
+
+```yaml
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ClusterQueue
+metadata:
+  name: cluster-queue
+spec:
+  # ... resourceGroups ...
+  admissionChecksStrategy:
+    admissionChecks:
+      - name: multikueue-check     # ← with this, nothing runs locally any more
+```
+
+### Verify
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-manager get multikueuecluster
+NAME         CONNECTED   AGE
+mk-worker1   True        3m
+mk-worker2   True        3m
+```
+
+If `ACTIVE` is `False`, read the `MESSAGE` field — it explains almost every failure mode.
+See [Troubleshooting](#troubleshooting).
+
+---
+
+## Test 1: batch/v1 Job
+
+**Goal:** verify basic cross-cluster dispatch and observe quota taking effect on the worker side.
+
+### Scenario
+
+- Submit **3 Jobs**, each requesting **2 CPU**
+- Manager quota **10 CPU** (not a bottleneck)
+- Each worker quota **2 CPU** (the real gate)
+
+Expected: 2 Jobs run, one per worker; the 3rd queues because both workers are full.
+
+### Dispatch strategy
+
+This test uses **AllAtOnce** (`kueue.x-k8s.io/multikueue-dispatcher-all-at-once`), configured
+via `multiKueue.dispatcherName` in `manifests/kueue-config.yaml`. Behaviour: once a Workload
+reaches `QuotaReserved` on the manager, a copy is created on mk-worker1 **and** mk-worker2
+simultaneously; the first to admit wins and the loser copy is deleted.
+
+### Run
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % ./scripts/run-demo-job.sh
+==> deleting demo workloads on mk-manager
+==> sweeping mk-worker1
+==> sweeping mk-worker2
+==> queues are empty:
+mk-worker1   0     0
+mk-worker2   0     0
+==> submitting 3 batch/Jobs to mk-manager
+job.batch/demo-job-1 created
+job.batch/demo-job-2 created
+job.batch/demo-job-3 created
+==> waiting for MultiKueue to dispatch...
+
+==> MANAGER (mk-manager) — submitted here, but nothing executes here
+NAME                   STATUS    COMPLETIONS   DURATION   AGE
+job.batch/demo-job-1   Running   0/1                      6s
+job.batch/demo-job-2   Running   0/1           5s         6s
+job.batch/demo-job-3   Running   0/1           4s         6s
+  pods on the manager (expected: none):
+  <none>
+
+==> MANAGER — Workloads: which worker cluster each one was dispatched to
+WORKLOAD               ADMITTED   DISPATCHED-TO   MESSAGE
+job-demo-job-1-a9067   <none>     <none>
+job-demo-job-2-dd6ff   True       mk-worker2      The workload was admitted on "mk-worker2"
+job-demo-job-3-53d6e   True       mk-worker1      The workload was admitted on "mk-worker1"
+
+==> WORKER (mk-worker1) — the Pods actually run here
+NAME                   STATUS    COMPLETIONS   DURATION   AGE
+job.batch/demo-job-3   Running   0/1           4s         4s
+NAME               READY   STATUS    RESTARTS   AGE
+demo-job-3-lhjdn   1/1     Running   0          4s
+CLUSTERQUEUE    PENDING   ADMITTED
+cluster-queue   1         1
+
+==> WORKER (mk-worker2) — the Pods actually run here
+NAME                   STATUS    COMPLETIONS   DURATION   AGE
+job.batch/demo-job-2   Running   0/1           5s         5s
+NAME               READY   STATUS    RESTARTS   AGE
+demo-job-2-lhjct   1/1     Running   0          5s
+CLUSTERQUEUE    PENDING   ADMITTED
+cluster-queue   1         1
+```
+
+### Reading the result
+
+| Observation | Output | Meaning |
+|---|---|---|
+| Pods on the manager | `<none>` | **the core proof MultiKueue works** |
+| demo-job-2 | `mk-worker2` | dispatched to worker2 |
+| demo-job-3 | `mk-worker1` | dispatched to worker1 |
+| demo-job-1 | `ADMITTED <none>` | manager quota was fine, both workers full |
+| worker `PENDING 1` | on both workers | AllAtOnce created demo-job-1's copy on **both**, both queued |
+
+That `PENDING 1` column is the key to understanding AllAtOnce: the same Workload queues on
+two clusters at once; whichever frees capacity first runs it, and the other copy is deleted.
+
+### Verify managedBy by hand
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-manager -n default get job demo-job-1 \
+  -o custom-columns='JOB:.metadata.name,SUSPEND:.spec.suspend,MANAGED-BY:.spec.managedBy'
+JOB          SUSPEND   MANAGED-BY
+demo-job-1   true      kueue.x-k8s.io/multikueue
+```
+
+We never wrote `managedBy` in the YAML — the Kueue webhook stamped it, because `user-queue`
+points at a ClusterQueue carrying a MultiKueue AdmissionCheck. The manager's native Job
+controller sees a value that is not its own and leaves the object entirely alone.
+
+### Inspect the full Workload status
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-manager -n default get workload -o yaml | grep -A 40 "  status:"
+  status:
+    admission:
+      clusterQueue: cluster-queue
+      podSetAssignments:
+      - count: 2
+        flavors:
+          cpu: default-flavor
+          memory: default-flavor
+        name: workers
+        resourceUsage:
+          cpu: "1"
+          memory: 400Mi
+    admissionChecks:
+    - lastTransitionTime: "2026-08-14T14:56:12Z"
+      message: The workload was admitted on "mk-worker2"
+      name: multikueue-check
+      state: Ready
+    clusterName: mk-worker2
+    conditions:
+    - lastTransitionTime: "2026-08-14T14:56:11Z"
+      message: Quota reserved in ClusterQueue cluster-queue
+      observedGeneration: 1
+      reason: QuotaReserved
+      status: "True"
+      type: QuotaReserved
+    - lastTransitionTime: "2026-08-14T14:56:12Z"
+      message: The workload is admitted
+      observedGeneration: 1
+      reason: Admitted
+      status: "True"
+      type: Admitted
+    - lastTransitionTime: "2026-08-14T14:56:16Z"
+      message: All pods reached readiness and the workload is running
+      observedGeneration: 1
+      reason: Started
+      status: "True"
+      type: PodsReady
+```
+
+The two gates are clearest here: `QuotaReserved` (manager let it through) → `Admitted`
+(a worker took it).
+
+---
+
+## Test 2: JobSet
+
+**Goal:** verify a multi-pod gang workload is dispatched to a single cluster **as a unit**,
+never split across clusters.
+
+### Scenario
+
+One JobSet with 2 replicated Jobs, 500m CPU each (1 CPU total).
+
+### Dispatch strategy
+
+**AllAtOnce** again — the dispatcher is a Kueue-level setting and applies to every workload
+type, not per framework.
+
+### Run
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % ./scripts/run-demo-jobset.sh
+==> deleting demo workloads on mk-manager
+==> sweeping mk-worker1
+==> sweeping mk-worker2
+==> queues are empty:
+mk-worker1   0     0
+mk-worker2   0     0
+==> submitting a JobSet to mk-manager
+jobset.jobset.x-k8s.io/demo-jobset created
+==> spec.managedBy defaulted by the Kueue webhook on the manager:
+demo-jobset  managedBy=kueue.x-k8s.io/multikueue  suspend=false
+==> waiting for MultiKueue to dispatch...
+==> dispatched to mk-worker2
+
+==> MANAGER (mk-manager) — submitted here, but nothing executes here
+NAME                                 TERMINALSTATE   RESTARTS   COMPLETED   SUSPENDED   AGE
+jobset.jobset.x-k8s.io/demo-jobset                                          false       2s
+  pods on the manager (expected: none):
+  <none>
+
+==> MANAGER — Workloads: which worker cluster each one was dispatched to
+WORKLOAD                   ADMITTED   DISPATCHED-TO   MESSAGE
+jobset-demo-jobset-0e211   True       mk-worker2      The workload was admitted on "mk-worker2"
+
+==> WORKER (mk-worker1) — the Pods actually run here
+CLUSTERQUEUE    PENDING   ADMITTED
+cluster-queue   0         0
+
+==> WORKER (mk-worker2) — the Pods actually run here
+NAME                              STATUS    COMPLETIONS   DURATION   AGE
+job.batch/demo-jobset-workers-0   Running   0/1           2s         2s
+job.batch/demo-jobset-workers-1   Running   0/1           2s         2s
+NAME                                 TERMINALSTATE   RESTARTS   COMPLETED   SUSPENDED   AGE
+jobset.jobset.x-k8s.io/demo-jobset                   0                      false       2s
+NAME                            READY   STATUS              RESTARTS   AGE
+demo-jobset-workers-0-0-p44m7   0/1     ContainerCreating   0          2s
+demo-jobset-workers-1-0-9xqnm   0/1     ContainerCreating   0          2s
+CLUSTERQUEUE    PENDING   ADMITTED
+cluster-queue   0         1
+```
+
+### Reading the result
+
+| Observation | Output | Meaning |
+|---|---|---|
+| JobSet on the manager | exists, `SUSPENDED false` | a shadow object only |
+| **Child Jobs** on the manager | none | the JobSet controller stood down because of `managedBy` |
+| Pods on the manager | `<none>` | ✓ |
+| mk-worker2 | 2 child Jobs + 2 Pods | the whole JobSet landed on **one** cluster |
+| mk-worker1 | empty | ✓ **the gang was not split across clusters** |
+
+This is the key difference from "spray pods across clusters": **the unit of dispatch is the
+entire Workload**, which is what makes pod-to-pod communication in distributed training work.
+
+`managedBy=kueue.x-k8s.io/multikueue` appeared 2 seconds after submission, stamped by the
+webhook — our YAML does not contain it:
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % grep -c managedBy examples/jobset.yaml
+0
+```
+
+---
+
+## Test 3: RayJob
+
+**Goal:** verify a workload that **dynamically creates child resources** (a RayCluster) has
+those children created only on the target worker.
+
+### Scenario
+
+One RayJob: head 500m/2Gi + 1 worker 500m/1Gi (1 CPU / 3Gi total, fits the worker's
+2 CPU / 4Gi quota). `shutdownAfterJobFinishes: true` tears the RayCluster down when the job
+completes, releasing quota.
+
+### Dispatch strategy
+
+**AllAtOnce** again.
+
+### Run
+
+The script pre-loads the Ray image into both workers first (a 177MB slim Ray image,
+far lighter than the multi-GB official `rayproject/ray`):
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % ./scripts/run-demo-rayjob.sh
+==> deleting demo workloads on mk-manager
+==> sweeping mk-worker1
+==> sweeping mk-worker2
+==> queues are empty:
+mk-worker1   0     0
+mk-worker2   0     0
+==> pre-pulling us-central1-docker.pkg.dev/k8s-staging-images/kueue/ray-project-mini:0.0.4 on the host
+==> loading the Ray image into mk-worker1
+==> loading the Ray image into mk-worker2
+==> submitting a RayJob to mk-manager
+rayjob.ray.io/demo-rayjob created
+==> spec.managedBy defaulted by the Kueue webhook on the manager:
+demo-rayjob  managedBy=kueue.x-k8s.io/multikueue  suspend=
+==> waiting for MultiKueue to dispatch...
+==> dispatched to mk-worker2
+==> watching the RayCluster come up on the worker (Ctrl-C is safe)...
+  demo-rayjob-mm7f9-head-7zzgz                 0/1   Running       0     2s
+  demo-rayjob-mm7f9-small-group-worker-llslc   0/1   Init:0/1      0     2s
+
+==> MANAGER (mk-manager) — submitted here, but nothing executes here
+NAME                        JOB STATUS   DEPLOYMENT STATUS   RAY CLUSTER NAME    START TIME             END TIME   AGE
+rayjob.ray.io/demo-rayjob                Initializing        demo-rayjob-mm7f9   2026-08-14T14:55:38Z              3s
+  pods on the manager (expected: none):
+  <none>
+
+==> MANAGER — Workloads: which worker cluster each one was dispatched to
+WORKLOAD                   ADMITTED   DISPATCHED-TO   MESSAGE
+rayjob-demo-rayjob-a5a54   True       mk-worker2      The workload was admitted on "mk-worker2"
+
+==> WORKER (mk-worker1) — the Pods actually run here
+CLUSTERQUEUE    PENDING   ADMITTED
+cluster-queue   0         0
+
+==> WORKER (mk-worker2) — the Pods actually run here
+NAME                        JOB STATUS   DEPLOYMENT STATUS   RAY CLUSTER NAME    START TIME             END TIME   AGE
+rayjob.ray.io/demo-rayjob                Initializing        demo-rayjob-mm7f9   2026-08-14T14:55:38Z              2s
+NAME                                         READY   STATUS   RESTARTS   AGE
+demo-rayjob-mm7f9-head-7zzgz                 0/1     Running  0          2s
+demo-rayjob-mm7f9-small-group-worker-llslc   0/1     Init:0/1 0          2s
+CLUSTERQUEUE    PENDING   ADMITTED
+cluster-queue   0         1
+
+==> waiting for the RayJob to finish...
+==> final state on the manager (status synced back from the worker):
+NAME          JOB-STATUS   DEPLOYMENT   MANAGED-BY
+demo-rayjob   SUCCEEDED    Running      kueue.x-k8s.io/multikueue
+WORKLOAD                   FINISHED   RAN-ON
+rayjob-demo-rayjob-a5a54   <none>     mk-worker2
+  pods on the manager (expected: none):
+  No resources found in default namespace.
+```
+
+### Reading the result
+
+| Observation | Output | Meaning |
+|---|---|---|
+| RayJob on the manager | exists, `RAY CLUSTER NAME` populated | status synced back from the worker |
+| **RayCluster pods** on the manager | `<none>` | KubeRay operator created none, because of `managedBy` |
+| mk-worker2 | head + worker pods | the RayCluster was only materialised here |
+| Manager's final `JOB-STATUS` | `SUCCEEDED` | **the worker's execution result synced back to the manager** |
+
+That last row is direct proof of MultiKueue's status sync: the user only ever talks to the
+manager, yet sees the real result from the worker.
+
+### Watch the RayCluster lifecycle
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-worker2 -n default get events --sort-by=.lastTimestamp | tail -8
+53s   Normal  CreatedService          rayjob/demo-rayjob    Created the service default/demo-rayjob-head-svc
+53s   Normal  CreatedRayJobSubmitter  rayjob/demo-rayjob    Created Kubernetes Job default/demo-rayjob
+52s   Normal  Started                 pod/demo-rayjob-mlv7m Container started
+43s   Normal  DeletedRayCluster       rayjob/demo-rayjob    Deleted cluster default/demo-rayjob-4sp5h
+43s   Normal  Killing                 pod/demo-rayjob-4sp5h-head-nmg2m  Stopping container ray-head
+43s   Normal  Completed               job/demo-rayjob       Job completed
+```
+
+`Job completed` → `DeletedRayCluster` is `shutdownAfterJobFinishes: true` doing its work,
+and the worker's quota is released with it.
+
+---
+
+## Troubleshooting
+
+### Pitfall 1: a missing JobSet CRD breaks the connection
+
+**Symptom:**
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-manager get multikueuecluster \
+  -o custom-columns='CLUSTER:.metadata.name,ACTIVE:.status.conditions[?(@.type=="Active")].status,REASON:.status.conditions[?(@.type=="Active")].reason,MESSAGE:.status.conditions[?(@.type=="Active")].message'
+CLUSTER      ACTIVE   REASON                   MESSAGE
+mk-worker1   False    ClientConnectionFailed   no matches for kind "JobSet" in version "jobset.x-k8s.io/v1alpha2"
+mk-worker2   False    ClientConnectionFailed   no matches for kind "JobSet" in version "jobset.x-k8s.io/v1alpha2"
+
+CHECK              ACTIVE   MESSAGE
+multikueue-check   False    Inactive clusters: [mk-worker1 mk-worker2]
+```
+
+**Cause:** Kueue enables jobset / appwrapper / trainer / lws and more by default. MultiKueue
+opens a watch per enabled framework on each worker; a missing CRD fails the whole connection.
+
+**Fix:** either
+
+1. install all those operators on **every** worker, or
+2. narrow `integrations.frameworks` to what is actually installed (what this demo does — see
+   `manifests/kueue-config.yaml`). The controller must be restarted afterwards:
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-manager apply -f manifests/kueue-config.yaml
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-manager -n kueue-system rollout restart deployment/kueue-controller-manager
+```
+
+### Pitfall 2: the manager cannot reach the worker (kind networking)
+
+**Symptom:** `Active=False` with `connection refused` or `i/o timeout` in MESSAGE.
+
+**Cause:** the kubeconfig's server is `https://127.0.0.1:<port>`. Works from the host, not
+from the manager's pod.
+
+**Check:**
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-manager -n kueue-system get secret mk-worker1-secret \
+  -o jsonpath='{.data.kubeconfig}' | base64 -d | grep server
+    server: https://172.19.0.3:6443
+```
+
+It must be a `172.x.x.x` in-network address. If it says `127.0.0.1`, re-run
+`./scripts/4-connect.sh`.
+
+### Pitfall 3: the RayJob head container is OOMKilled
+
+**Symptom:** the head pod is in `CrashLoopBackOff` with **no log output at all**.
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-worker1 -n default get pod <head-pod> \
+  -o jsonpath='{.status.containerStatuses[0].lastState}'
+{"terminated":{"exitCode":137,"reason":"OOMKilled",...}}
+```
+
+**Cause:** not enough memory for the Ray head. `exitCode 137` = OOMKilled.
+
+**Fix:** give the head at least 4Gi of `limits.memory` (this demo uses 8Gi). Note that Kueue
+counts **requests**, not limits, so you can request 2Gi and limit 8Gi — neither blowing the
+quota nor OOMing.
+
+### Pitfall 4: Ray object store sizing error
+
+**Symptom:**
+
+```
+ValueError: Attempting to cap object store memory usage at 1146470 bytes,
+but the minimum allowed is 78643200 bytes.
+```
+
+**Fix:** set it explicitly in `rayStartParams`:
+
+```yaml
+rayStartParams:
+  object-store-memory: "134217728"
+```
+
+### Pitfall 5: `kind load docker-image` fails
+
+**Symptom:**
+
+```
+ERROR: failed to load image: ... ctr: content digest sha256:...: not found
+```
+
+**Cause:** `kind load docker-image` re-imports with `--all-platforms`; for a multi-arch image
+only the local platform's layers exist, so the other platforms' digests are missing.
+
+**Fix:** save a single-platform archive first:
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % docker save --platform linux/arm64 <image> -o image.tar
+gyliu-cary@Mac multikueue-minimal-demo % kind load image-archive image.tar --name mk-worker1
+```
+
+### Pitfall 6: Workload stuck pending, nothing on any worker
+
+**Check in this order:**
+
+```console
+# 1. is the AdmissionCheck Active?
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-manager get admissioncheck multikueue-check -o yaml | grep -A5 conditions
+
+# 2. does the worker have a same-named namespace and LocalQueue? (names must match exactly)
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-worker1 -n default get localqueue
+
+# 3. do the worker's ResourceFlavor names match the manager's?
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-worker1 get resourceflavor
+
+# 4. is the worker's quota simply too small for this Workload?
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-worker1 get clusterqueue cluster-queue -o yaml | grep -A20 "status:"
+
+# 5. read the manager's Kueue logs
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-manager -n kueue-system logs deployment/kueue-controller-manager --tail=100 | grep -i multikueue
+```
+
+### General status check
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % ./scripts/status.sh
+```
+
+---
+
+## Cleanup
+
+Wipe the workloads but keep the clusters (handy for repeated experiments):
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % ./scripts/clean-workloads.sh
+==> deleting demo workloads on mk-manager
+==> sweeping mk-worker1
+==> sweeping mk-worker2
+==> queues are empty:
+mk-worker1   0     0
+mk-worker2   0     0
+```
+
+Delete the whole environment:
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % ./scripts/down.sh
+==> deleting cluster mk-manager
+Deleting cluster "mk-manager" ...
+==> deleting cluster mk-worker1
+Deleting cluster "mk-worker1" ...
+==> deleting cluster mk-worker2
+Deleting cluster "mk-worker2" ...
+==> torn down
+```
+
+Equivalent manual command:
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kind delete clusters mk-manager mk-worker1 mk-worker2
+```

--- a/kueue/multikueue-minimal-demo/WALKTHROUGH.zh-CN.md
+++ b/kueue/multikueue-minimal-demo/WALKTHROUGH.zh-CN.md
@@ -1,0 +1,1181 @@
+# MultiKueue Demo 分步操作手册
+
+> English: [WALKTHROUGH.md](WALKTHROUGH.md) · 架构原理：[README.zh-CN.md](README.zh-CN.md)
+
+本文档记录搭建全过程的**每一条命令和它的真实输出**（在 macOS / Apple Silicon / Docker
+Desktop 上实际执行采集）。原理和架构见 [README.zh-CN.md](README.zh-CN.md)。
+
+**目录**
+
+- [第 0 步：安装前置工具](#第-0-步安装前置工具)
+- [第 1 步：创建 3 个 kind 集群](#第-1-步创建-3-个-kind-集群)
+- [集群上下文切换](#集群上下文切换context-switching)
+- [第 2 步：安装 JobSet 和 KubeRay](#第-2-步安装-jobset-和-kuberay)
+- [第 3 步：安装 Kueue 并启用 MultiKueue](#第-3-步安装-kueue-并启用-multikueue)
+- [第 4 步：配置 worker 队列](#第-4-步配置-worker-队列)
+- [第 5 步：打通 manager 到 worker 的连接](#第-5-步打通-manager-到-worker-的连接)
+- [第 6 步：在 manager 上接线 MultiKueue](#第-6-步在-manager-上接线-multikueue)
+- [测试 1：batch/v1 Job](#测试-1batchv1-job)
+- [测试 2：JobSet](#测试-2jobset)
+- [测试 3：RayJob](#测试-3rayjob)
+- [排错手册](#排错手册)
+- [清理](#清理)
+
+---
+
+## 第 0 步：安装前置工具
+
+### 0.1 Docker
+
+MultiKueue demo 需要同时跑 3 个 kind 集群，建议给 Docker 至少 **8GB 内存**（跑 RayJob 建议
+12GB+）。macOS 上从 Docker Desktop → Settings → Resources 调整。
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % docker info --format '{{.MemTotal}} {{.NCPU}}'
+24898469888 14
+```
+
+### 0.2 kind
+
+必须 **≥ v0.31.0**（默认节点镜像为 k8s v1.35.0）。
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % brew install kind
+```
+
+其他平台：
+
+```console
+# Linux amd64
+gyliu-cary@Mac ~ % curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.31.0/kind-linux-amd64
+gyliu-cary@Mac ~ % chmod +x ./kind && sudo mv ./kind /usr/local/bin/kind
+
+# macOS Apple Silicon（不用 brew 时）
+gyliu-cary@Mac ~ % curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.31.0/kind-darwin-arm64
+gyliu-cary@Mac ~ % chmod +x ./kind && sudo mv ./kind /usr/local/bin/kind
+```
+
+验证：
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kind version
+kind v0.31.0 go1.25.5 darwin/arm64
+```
+
+### 0.3 kubectl 和 helm
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % brew install kubectl helm
+```
+
+验证：
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl version --client
+Client Version: v1.32.2
+Kustomize Version: v5.5.0
+```
+
+`helm` 只用来装 KubeRay operator。Kueue 和 JobSet 都是直接 apply 官方发布的
+`manifests.yaml`，不需要 helm。
+
+---
+
+## 第 1 步：创建 3 个 kind 集群
+
+一个 manager，两个 worker，每个都是单节点集群。
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % ./scripts/0-create-clusters.sh
+==> creating cluster mk-manager
+Creating cluster "mk-manager" ...
+ • Ensuring node image (kindest/node:v1.35.0) 🖼  ...
+ ✓ Ensuring node image (kindest/node:v1.35.0) 🖼
+ • Preparing nodes 📦   ...
+ ✓ Preparing nodes 📦
+ • Writing configuration 📜  ...
+ ✓ Writing configuration 📜
+ • Starting control-plane 🕹️  ...
+ ✓ Starting control-plane 🕹️
+ • Installing CNI 🔌  ...
+ ✓ Installing CNI 🔌
+ • Installing StorageClass 💾  ...
+ ✓ Installing StorageClass 💾
+ • Waiting ≤ 2m0s for control-plane = Ready ⏳  ...
+ ✓ Waiting ≤ 2m0s for control-plane = Ready ⏳
+ • Ready after 16s 💚
+Set kubectl context to "kind-mk-manager"
+
+==> creating cluster mk-worker1
+Creating cluster "mk-worker1" ...
+ ✓ Ready after 17s 💚
+Set kubectl context to "kind-mk-worker1"
+
+==> creating cluster mk-worker2
+Creating cluster "mk-worker2" ...
+ ✓ Ready after 16s 💚
+Set kubectl context to "kind-mk-worker2"
+
+==> clusters ready:
+mk-manager
+mk-worker1
+mk-worker2
+```
+
+等价的手工命令：
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kind create cluster --name mk-manager --image kindest/node:v1.35.0 --wait 120s
+gyliu-cary@Mac multikueue-minimal-demo % kind create cluster --name mk-worker1 --image kindest/node:v1.35.0 --wait 120s
+gyliu-cary@Mac multikueue-minimal-demo % kind create cluster --name mk-worker2 --image kindest/node:v1.35.0 --wait 120s
+```
+
+### 验证
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kind get clusters
+mk-manager
+mk-worker1
+mk-worker2
+```
+
+kind 会自动往 kubeconfig 里写 3 个 context：
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl config get-contexts | grep mk-
+*         kind-mk-manager   kind-mk-manager   kind-mk-manager
+          kind-mk-worker1   kind-mk-worker1   kind-mk-worker1
+          kind-mk-worker2   kind-mk-worker2   kind-mk-worker2
+```
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-manager get nodes
+NAME                       STATUS   ROLES           AGE   VERSION
+mk-manager-control-plane   Ready    control-plane   27m   v1.35.0
+```
+
+### 关键点：3 个集群在同一个 docker 网络里
+
+kind 默认把所有集群放进名为 `kind` 的 docker bridge 网络。**这是 manager 能连上 worker
+API server 的前提**：
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % docker network inspect kind -f '{{range .Containers}}{{.Name}} {{.IPv4Address}}{{"\n"}}{{end}}' | grep control-plane
+mk-manager-control-plane 172.19.0.2/16
+mk-worker1-control-plane 172.19.0.3/16
+mk-worker2-control-plane 172.19.0.4/16
+```
+
+第 5 步会用到这几个 IP。
+
+---
+
+## 集群上下文切换（Context Switching）
+
+这个 demo 有 3 个集群，验证过程中需要频繁在 manager 和 worker 之间来回查 Pod。这一节把
+所有切换方式集中说明。
+
+### 三个 context 的名字
+
+kind 建集群时会自动往 `~/.kube/config` 里写入 context，命名规则是 `kind-<集群名>`：
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl config get-contexts | grep mk-
+*         kind-mk-manager   kind-mk-manager   kind-mk-manager
+          kind-mk-worker1   kind-mk-worker1   kind-mk-worker1
+          kind-mk-worker2   kind-mk-worker2   kind-mk-worker2
+```
+
+| 集群 | context 名字 | 角色 |
+|---|---|---|
+| mk-manager | `kind-mk-manager` | 提交作业、看 Workload 分发结果 |
+| mk-worker1 | `kind-mk-worker1` | 看真正运行的 Pod |
+| mk-worker2 | `kind-mk-worker2` | 看真正运行的 Pod |
+
+### 方式一：`--context` 一次性指定（推荐）
+
+**不改变当前默认 context**，最安全，本手册里所有命令都用这种写法：
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-manager -n default get workloads
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-worker1 -n default get pods
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-worker2 -n default get pods
+```
+
+好处是可以在**同一行命令里对比多个集群**，不会因为忘记切回去而误操作：
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % for c in manager worker1 worker2; do \
+  echo "--- $c"; kubectl --context kind-mk-$c -n default get pods --no-headers 2>&1; done
+--- manager
+No resources found in default namespace.
+--- worker1
+demo-job-3-lhjdn   1/1   Running   0   12s
+--- worker2
+demo-job-2-lhjct   1/1   Running   0   13s
+```
+
+这条命令一眼就能看出 MultiKueue 生效了：manager 上没有 Pod，两个 worker 上各有一个。
+
+### 方式二：切换默认 context
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl config use-context kind-mk-worker1
+Switched to context "kind-mk-worker1".
+```
+
+查看当前指向哪个集群：
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl config current-context
+kind-mk-worker1
+```
+
+切完之后不带 `--context` 的命令就作用在这个集群上：
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl get nodes
+NAME                       STATUS   ROLES           AGE   VERSION
+mk-worker1-control-plane   Ready    control-plane   38m   v1.35.0
+```
+
+切回 manager：
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl config use-context kind-mk-manager
+Switched to context "kind-mk-manager".
+```
+
+### 方式三：用本 demo 的辅助脚本
+
+`scripts/ctx.sh` 封装了上面的操作，参数支持简写：
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % ./scripts/ctx.sh
+==> demo contexts (* = current):
+  * kind-mk-manager
+    kind-mk-worker1
+    kind-mk-worker2
+
+usage: ./scripts/ctx.sh <manager|worker1|worker2>
+```
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % ./scripts/ctx.sh worker1
+Switched to context "kind-mk-worker1".
+==> now pointing at mk-worker1
+NAME                       STATUS   ROLES           AGE   VERSION
+mk-worker1-control-plane   Ready    control-plane   38m   v1.35.0
+```
+
+支持的简写：`manager` / `mgr` / `m`，`worker1` / `w1` / `1`，`worker2` / `w2` / `2`。
+
+### 方式四：定义 shell 别名（做实验时最省事）
+
+把这几行贴进当前终端（或写进 `~/.zshrc`）：
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % alias kmgr='kubectl --context kind-mk-manager'
+gyliu-cary@Mac multikueue-minimal-demo % alias kw1='kubectl --context kind-mk-worker1'
+gyliu-cary@Mac multikueue-minimal-demo % alias kw2='kubectl --context kind-mk-worker2'
+```
+
+之后就可以这样用：
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kmgr -n default get workloads
+gyliu-cary@Mac multikueue-minimal-demo % kw1 -n default get pods
+gyliu-cary@Mac multikueue-minimal-demo % kw2 -n default get pods
+```
+
+### 方式五：kubectx（第三方工具）
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % brew install kubectx
+gyliu-cary@Mac multikueue-minimal-demo % kubectx kind-mk-worker1
+gyliu-cary@Mac multikueue-minimal-demo % kubectx -          # 回到上一个 context
+```
+
+### 常用对照速查
+
+| 想看什么 | 在哪个集群 | 命令 |
+|---|---|---|
+| 提交的 Job/JobSet/RayJob | manager | `kubectl --context kind-mk-manager -n default get jobs,jobsets,rayjobs` |
+| Workload 被派到哪 | manager | `kubectl --context kind-mk-manager -n default get workloads -o custom-columns='WL:.metadata.name,RAN-ON:.status.clusterName'` |
+| MultiKueue 连接状态 | manager | `kubectl --context kind-mk-manager get multikueuecluster` |
+| **真正运行的 Pod** | worker | `kubectl --context kind-mk-worker1 -n default get pods` |
+| worker 配额使用情况 | worker | `kubectl --context kind-mk-worker1 get clusterqueue cluster-queue` |
+| Kueue 控制器日志 | manager | `kubectl --context kind-mk-manager -n kueue-system logs deployment/kueue-controller-manager` |
+
+> `./scripts/status.sh` 会自动遍历 3 个集群，把上面这些一次性打出来，不用手工切换。
+
+---
+
+## 第 2 步：安装 JobSet 和 KubeRay
+
+**必须在装 Kueue 之前做。** Kueue 在启动时才判断哪些集成可以启用（依据是对应 CRD 是否存在），
+CRD 后装的话 Kueue 不会自动感知。
+
+三个集群**都要装**，包括 manager。原因：MultiKueue 需要在 manager 上保存一份 JobSet/RayJob
+的"影子副本"。两个 operator 都遵守 `spec.managedBy=kueue.x-k8s.io/multikueue`，在 manager
+上看到这个字段就主动不干活，所以 manager 上不会产生任何 Pod。
+（要求 JobSet ≥ v0.6.0、KubeRay ≥ v1.3.1。）
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % ./scripts/1-install-frameworks.sh
+==> adding the kuberay helm repo
+==> installing JobSet v0.12.0 on mk-manager
+==> installing KubeRay 1.6.2 on mk-manager
+Release "kuberay-operator" does not exist. Installing it now.
+NAME: kuberay-operator
+LAST DEPLOYED: Fri Aug 14 10:44:19 2026
+NAMESPACE: kuberay-system
+STATUS: deployed
+REVISION: 1
+
+==> installing JobSet v0.12.0 on mk-worker1
+==> installing KubeRay 1.6.2 on mk-worker1
+...
+==> waiting for the JobSet controller on mk-manager
+deployment "jobset-controller-manager" successfully rolled out
+==> waiting for the JobSet controller on mk-worker1
+deployment "jobset-controller-manager" successfully rolled out
+==> waiting for the JobSet controller on mk-worker2
+deployment "jobset-controller-manager" successfully rolled out
+
+==> framework CRDs now available:
+--- mk-manager
+jobsets.jobset.x-k8s.io
+rayjobs.ray.io
+rayclusters.ray.io
+rayservices.ray.io
+--- mk-worker1
+jobsets.jobset.x-k8s.io
+rayjobs.ray.io
+rayclusters.ray.io
+rayservices.ray.io
+--- mk-worker2
+jobsets.jobset.x-k8s.io
+rayjobs.ray.io
+rayclusters.ray.io
+rayservices.ray.io
+```
+
+等价的手工命令（对每个 context 各跑一遍）：
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-manager apply --server-side \
+  -f https://github.com/kubernetes-sigs/jobset/releases/download/v0.12.0/manifests.yaml
+
+gyliu-cary@Mac multikueue-minimal-demo % helm repo add kuberay https://ray-project.github.io/kuberay-helm/
+gyliu-cary@Mac multikueue-minimal-demo % helm --kube-context kind-mk-manager upgrade --install kuberay-operator \
+  kuberay/kuberay-operator --version 1.6.2 -n kuberay-system --create-namespace --wait
+```
+
+### 验证
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-manager get pods -A | grep -E "jobset|kuberay"
+jobset-system        jobset-controller-manager-5585d4c665-c9qf4         1/1     Running   0          14m
+kuberay-system       kuberay-operator-5dff8cd9d5-wz9nm                  1/1     Running   0          14m
+```
+
+---
+
+## 第 3 步：安装 Kueue 并启用 MultiKueue
+
+### 3.1 MultiKueue 需要额外"开启"吗？
+
+**不需要。** `MultiKueue` 特性门控自 Kueue v0.9 起就是 **Beta 且默认开启**：
+
+```go
+// pkg/features/kube_features.go
+MultiKueue: {
+    {Version: version.MustParse("0.6"), Default: false, PreRelease: featuregate.Alpha},
+    {Version: version.MustParse("0.9"), Default: true,  PreRelease: featuregate.Beta},
+},
+```
+
+所以装完 Kueue 就能用，不用加任何 `--feature-gates` 参数。真正让 MultiKueue "生效"的动作是
+第 6 步创建那几个 CR（AdmissionCheck / MultiKueueConfig / MultiKueueCluster）。
+
+### 3.2 安装
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % ./scripts/2-install-kueue.sh
+==> installing Kueue v0.19.1 on mk-manager
+==> pinning enabled integrations on mk-manager
+configmap/kueue-manager-config configured
+deployment.apps/kueue-controller-manager restarted
+==> installing Kueue v0.19.1 on mk-worker1
+==> pinning enabled integrations on mk-worker1
+configmap/kueue-manager-config configured
+deployment.apps/kueue-controller-manager restarted
+==> installing Kueue v0.19.1 on mk-worker2
+==> pinning enabled integrations on mk-worker2
+configmap/kueue-manager-config configured
+deployment.apps/kueue-controller-manager restarted
+==> waiting for kueue-controller-manager on mk-manager
+deployment "kueue-controller-manager" successfully rolled out
+==> waiting for kueue-controller-manager on mk-worker1
+deployment "kueue-controller-manager" successfully rolled out
+==> waiting for kueue-controller-manager on mk-worker2
+deployment "kueue-controller-manager" successfully rolled out
+==> enabled integrations (should list batch/job, jobset and the ray kinds):
+integrations:
+  frameworks:
+  - "batch/job"
+  - "jobset.x-k8s.io/jobset"
+  - "ray.io/rayjob"
+  - "ray.io/raycluster"
+  - "ray.io/rayservice"
+```
+
+等价的手工命令：
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-manager apply --server-side \
+  -f https://github.com/kubernetes-sigs/kueue/releases/download/v0.19.1/manifests.yaml
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-manager apply -f manifests/kueue-config.yaml
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-manager -n kueue-system rollout restart deployment/kueue-controller-manager
+```
+
+### 3.3 为什么必须改 ConfigMap
+
+这是本 demo 最重要的一个坑。Kueue 默认启用了一大堆集成：
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-manager -n kueue-system get cm kueue-manager-config \
+  -o jsonpath='{.data.controller_manager_config\.yaml}' | grep -A 20 "^integrations:"
+integrations:
+  frameworks:
+  - "batch/job"
+  - "kubeflow.org/mpijob"
+  - "ray.io/rayjob"
+  - "ray.io/raycluster"
+  - "ray.io/rayservice"
+  - "jobset.x-k8s.io/jobset"
+  - "workload.codeflare.dev/appwrapper"
+  - "trainer.kubeflow.org/trainjob"
+  - "pod"
+  - "deployment"
+  - "statefulset"
+  - "leaderworkerset.x-k8s.io/leaderworkerset"
+```
+
+MultiKueue 会**为每个启用的框架**在每个 worker 上建立 watch。worker 上没装 AppWrapper /
+Kubeflow Trainer / LeaderWorkerSet 的 CRD，watch 建不起来，整个集群连接就失败。所以
+`manifests/kueue-config.yaml` 把列表收窄到本 demo 实际安装的这几个。
+
+**规则：`integrations.frameworks` 必须和 worker 上实际装的 operator 严格对应。**
+
+### 3.4 配置里的分发策略
+
+同一个 ConfigMap 里还配了 MultiKueue 的分发策略：
+
+```yaml
+multiKueue:
+  dispatcherName: kueue.x-k8s.io/multikueue-dispatcher-all-at-once
+  workerLostTimeout: 15m
+  gcInterval: 1m
+```
+
+完整解释见 [README 第 5 节](README.zh-CN.md#5-分发策略dispatch-strategy)。
+
+### 验证
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-manager -n kueue-system get pods
+NAME                                        READY   STATUS    RESTARTS   AGE
+kueue-controller-manager-5cb5c9fbcd-mt4h2   1/1     Running   0          9m54s
+```
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-worker1 get crd | grep -E "jobset|ray.io|kueue"
+admissionchecks.kueue.x-k8s.io              2026-08-14T14:32:18Z
+clusterqueues.kueue.x-k8s.io                2026-08-14T14:32:18Z
+cohorts.kueue.x-k8s.io                      2026-08-14T14:32:18Z
+jobsets.jobset.x-k8s.io                     2026-08-14T14:44:18Z
+localqueues.kueue.x-k8s.io                  2026-08-14T14:32:18Z
+multikueueclusters.kueue.x-k8s.io           2026-08-14T14:32:18Z
+multikueueconfigs.kueue.x-k8s.io            2026-08-14T14:32:18Z
+provisioningrequestconfigs.kueue.x-k8s.io   2026-08-14T14:32:18Z
+rayclusters.ray.io                          2026-08-14T14:44:18Z
+raycronjobs.ray.io                          2026-08-14T14:44:18Z
+rayjobs.ray.io                              2026-08-14T14:44:18Z
+rayservices.ray.io                          2026-08-14T14:44:18Z
+```
+
+---
+
+## 第 4 步：配置 worker 队列
+
+worker 集群就是一个普通的独立 Kueue 集群。关键约束：**namespace 和 LocalQueue 的名字必须
+和 manager 完全一致**（这里是 `default` / `user-queue`），因为 MultiKueue 是把 Workload
+原样复制过去的。
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % ./scripts/3-setup-workers.sh
+==> applying queues on mk-worker1
+resourceflavor.kueue.x-k8s.io/default-flavor created
+clusterqueue.kueue.x-k8s.io/cluster-queue created
+localqueue.kueue.x-k8s.io/user-queue created
+==> applying queues on mk-worker2
+resourceflavor.kueue.x-k8s.io/default-flavor created
+clusterqueue.kueue.x-k8s.io/cluster-queue created
+localqueue.kueue.x-k8s.io/user-queue created
+==> worker queues:
+--- mk-worker1
+NAME                                        COHORT   PENDING WORKLOADS
+clusterqueue.kueue.x-k8s.io/cluster-queue            0
+
+NAMESPACE   NAME                                   CLUSTERQUEUE    PENDING WORKLOADS   ADMITTED WORKLOADS
+default     localqueue.kueue.x-k8s.io/user-queue   cluster-queue   0                   0
+--- mk-worker2
+NAME                                        COHORT   PENDING WORKLOADS
+clusterqueue.kueue.x-k8s.io/cluster-queue            0
+
+NAMESPACE   NAME                                   CLUSTERQUEUE    PENDING WORKLOADS   ADMITTED WORKLOADS
+default     localqueue.kueue.x-k8s.io/user-queue   cluster-queue   0                   0
+```
+
+worker 配额刻意设小（2 CPU / 4Gi），这样才能演示"配额压力在 worker 侧"：
+
+```yaml
+# manifests/worker-queues.yaml
+resources:
+  - name: cpu
+    nominalQuota: 2
+  - name: memory
+    nominalQuota: 4Gi
+```
+
+---
+
+## 第 5 步：打通 manager 到 worker 的连接
+
+这是**唯一**的跨集群连接机制：一份 kubeconfig，存成 manager 上的 Secret。
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % ./scripts/4-connect.sh
+==> creating MultiKueue ServiceAccount on mk-worker1
+serviceaccount/multikueue-sa created
+clusterrole.rbac.authorization.k8s.io/multikueue-sa-role created
+clusterrolebinding.rbac.authorization.k8s.io/multikueue-sa-crb created
+secret/multikueue-sa created
+==> waiting for the ServiceAccount token to be populated on mk-worker1
+==> mk-worker1 API server reachable in-network at https://172.19.0.3:6443
+==> storing mk-worker1 kubeconfig as a Secret on mk-manager
+secret/mk-worker1-secret created
+==> creating MultiKueue ServiceAccount on mk-worker2
+serviceaccount/multikueue-sa created
+clusterrole.rbac.authorization.k8s.io/multikueue-sa-role created
+clusterrolebinding.rbac.authorization.k8s.io/multikueue-sa-crb created
+secret/multikueue-sa created
+==> waiting for the ServiceAccount token to be populated on mk-worker2
+==> mk-worker2 API server reachable in-network at https://172.19.0.4:6443
+==> storing mk-worker2 kubeconfig as a Secret on mk-manager
+secret/mk-worker2-secret created
+==> connection secrets on the manager:
+mk-worker1-secret           Opaque   1      0s
+mk-worker2-secret           Opaque   1      0s
+```
+
+这一步做了三件事：
+
+**1）在 worker 上创建受限的 ServiceAccount**（`manifests/worker-multikueue-rbac.yaml`）。
+权限只覆盖 Kueue Workload + 本 demo 安装的三种框架。注意这个 ClusterRole 必须覆盖第 3 步
+`integrations.frameworks` 里的每一个框架，否则 manager 的 watch 会被 403 拒绝。
+
+**2）为该 SA 申请长期 token**。k8s 1.24 起不再自动给 SA 建 token Secret，要显式声明：
+
+```yaml
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/service-account-token
+metadata:
+  name: multikueue-sa
+  namespace: kueue-system
+  annotations:
+    kubernetes.io/service-account.name: multikueue-sa
+```
+
+**3）拼出 kubeconfig，注意 server 地址** ← **kind 环境最大的坑**
+
+`kind get kubeconfig` 给出的地址是 `https://127.0.0.1:<随机端口>`，**只在宿主机上有效**。
+manager 上的 Kueue Pod 跑在容器网络里，访问不到。必须换成 worker control-plane 容器在
+`kind` docker 网络上的 IP：
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % docker inspect -f '{{.NetworkSettings.Networks.kind.IPAddress}}' mk-worker1-control-plane
+172.19.0.3
+```
+
+kubeadm 会把这个 IP 写进 API server 的服务端证书 SAN，所以 TLS 校验照样通过，不需要
+`insecure-skip-tls-verify`。
+
+生成出来的 kubeconfig 长这样（token 已截断）：
+
+```yaml
+apiVersion: v1
+kind: Config
+clusters:
+  - name: mk-worker1
+    cluster:
+      certificate-authority-data: LS0tLS1CRUdJTiBDRVJU...
+      server: https://172.19.0.3:6443     # ← 容器网络内的地址，不是 127.0.0.1
+users:
+  - name: multikueue-sa
+    user:
+      token: eyJhbGciOiJSUzI1NiIsImtpZCI6...
+contexts:
+  - name: mk-worker1
+    context:
+      cluster: mk-worker1
+      user: multikueue-sa
+current-context: mk-worker1
+```
+
+### 验证
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-manager -n kueue-system get secret | grep -- -secret
+mk-worker1-secret           Opaque   1      12m
+mk-worker2-secret           Opaque   1      12m
+```
+
+---
+
+## 第 6 步：在 manager 上接线 MultiKueue
+
+创建那条对象链：`ClusterQueue → AdmissionCheck → MultiKueueConfig → MultiKueueCluster → Secret`。
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % ./scripts/5-setup-manager.sh
+==> applying MultiKueue setup on mk-manager
+resourceflavor.kueue.x-k8s.io/default-flavor created
+clusterqueue.kueue.x-k8s.io/cluster-queue created
+localqueue.kueue.x-k8s.io/user-queue created
+admissioncheck.kueue.x-k8s.io/multikueue-check created
+multikueueconfig.kueue.x-k8s.io/multikueue-config created
+multikueuecluster.kueue.x-k8s.io/mk-worker1 created
+multikueuecluster.kueue.x-k8s.io/mk-worker2 created
+==> waiting for both MultiKueueClusters to report Active
+CLUSTER      ACTIVE   REASON   MESSAGE
+mk-worker1   True     Active   Connected
+mk-worker2   True     Active   Connected
+
+CHECK              ACTIVE   MESSAGE
+multikueue-check   True     The admission check is active
+```
+
+**`Active=True / Connected` 就是环境搭好了的标志。**
+
+关键的一段是 ClusterQueue 上挂 AdmissionCheck ——「普通队列」和「跨集群派发队列」的唯一区别：
+
+```yaml
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ClusterQueue
+metadata:
+  name: cluster-queue
+spec:
+  # ... resourceGroups ...
+  admissionChecksStrategy:
+    admissionChecks:
+      - name: multikueue-check     # ← 加了这个，这个队列就不在本地跑任何东西了
+```
+
+### 验证
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-manager get multikueuecluster
+NAME         CONNECTED   AGE
+mk-worker1   True        3m
+mk-worker2   True        3m
+```
+
+如果 `ACTIVE` 是 `False`，直接看 `MESSAGE` 字段，绝大多数问题它都说清楚了 ——
+见[排错手册](#排错手册)。
+
+---
+
+## 测试 1：batch/v1 Job
+
+**目标**：验证最基础的跨集群派发，并观察配额如何在 worker 侧生效。
+
+### 场景设计
+
+- 提交 **3 个 Job**，每个请求 **2 CPU**
+- manager 配额 **10 CPU**（不构成瓶颈）
+- 每个 worker 配额 **2 CPU**（真正的闸门）
+
+预期：2 个 Job 各占一个 worker 跑起来，第 3 个因两边都满而排队。
+
+### 分发策略
+
+本测试用的是 **AllAtOnce**（`kueue.x-k8s.io/multikueue-dispatcher-all-at-once`），
+配置在 `manifests/kueue-config.yaml` 的 `multiKueue.dispatcherName`。
+行为是：Workload 在 manager 拿到 `QuotaReserved` 后，**同时**在 mk-worker1 和 mk-worker2
+上各建一份副本，谁先 admit 谁赢，输的那份被删除。
+
+### 执行
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % ./scripts/run-demo-job.sh
+==> deleting demo workloads on mk-manager
+==> sweeping mk-worker1
+==> sweeping mk-worker2
+==> queues are empty:
+mk-worker1   0     0
+mk-worker2   0     0
+==> submitting 3 batch/Jobs to mk-manager
+job.batch/demo-job-1 created
+job.batch/demo-job-2 created
+job.batch/demo-job-3 created
+==> waiting for MultiKueue to dispatch...
+
+==> MANAGER (mk-manager) — submitted here, but nothing executes here
+NAME                   STATUS    COMPLETIONS   DURATION   AGE
+job.batch/demo-job-1   Running   0/1                      6s
+job.batch/demo-job-2   Running   0/1           5s         6s
+job.batch/demo-job-3   Running   0/1           4s         6s
+  pods on the manager (expected: none):
+  <none>
+
+==> MANAGER — Workloads: which worker cluster each one was dispatched to
+WORKLOAD               ADMITTED   DISPATCHED-TO   MESSAGE
+job-demo-job-1-a9067   <none>     <none>
+job-demo-job-2-dd6ff   True       mk-worker2      The workload was admitted on "mk-worker2"
+job-demo-job-3-53d6e   True       mk-worker1      The workload was admitted on "mk-worker1"
+
+==> WORKER (mk-worker1) — the Pods actually run here
+NAME                   STATUS    COMPLETIONS   DURATION   AGE
+job.batch/demo-job-3   Running   0/1           4s         4s
+NAME               READY   STATUS    RESTARTS   AGE
+demo-job-3-lhjdn   1/1     Running   0          4s
+CLUSTERQUEUE    PENDING   ADMITTED
+cluster-queue   1         1
+
+==> WORKER (mk-worker2) — the Pods actually run here
+NAME                   STATUS    COMPLETIONS   DURATION   AGE
+job.batch/demo-job-2   Running   0/1           5s         5s
+NAME               READY   STATUS    RESTARTS   AGE
+demo-job-2-lhjct   1/1     Running   0          5s
+CLUSTERQUEUE    PENDING   ADMITTED
+cluster-queue   1         1
+```
+
+### 结果解读
+
+| 观察点 | 输出 | 说明 |
+|---|---|---|
+| manager 上的 Pod | `<none>` | **MultiKueue 生效的核心证据** |
+| demo-job-2 | `mk-worker2` | 被派到 worker2 |
+| demo-job-3 | `mk-worker1` | 被派到 worker1 |
+| demo-job-1 | `ADMITTED <none>` | manager 配额够，但两个 worker 都满了 |
+| worker `PENDING 1` | 两个 worker 都是 1 | AllAtOnce 在**两个** worker 上都建了 demo-job-1 的副本，都在排队 |
+
+`PENDING 1` 这一栏是理解 AllAtOnce 的关键：同一个 Workload 同时在两个集群排队，哪个先有
+空位就在哪跑，另一份会被删除。
+
+### 手工验证 managedBy
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-manager -n default get job demo-job-1 \
+  -o custom-columns='JOB:.metadata.name,SUSPEND:.spec.suspend,MANAGED-BY:.spec.managedBy'
+JOB          SUSPEND   MANAGED-BY
+demo-job-1   true      kueue.x-k8s.io/multikueue
+```
+
+`managedBy` 不是我们在 YAML 里写的，是 Kueue webhook 自动打上的 —— 因为
+`user-queue` 指向的 ClusterQueue 挂了 MultiKueue AdmissionCheck。manager 上的原生 Job
+控制器看到这个值不是自己，就完全不碰它。
+
+### 查看完整 Workload 状态
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-manager -n default get workload -o yaml | grep -A 40 "  status:"
+  status:
+    admission:
+      clusterQueue: cluster-queue
+      podSetAssignments:
+      - count: 2
+        flavors:
+          cpu: default-flavor
+          memory: default-flavor
+        name: workers
+        resourceUsage:
+          cpu: "1"
+          memory: 400Mi
+    admissionChecks:
+    - lastTransitionTime: "2026-08-14T14:56:12Z"
+      message: The workload was admitted on "mk-worker2"
+      name: multikueue-check
+      state: Ready
+    clusterName: mk-worker2
+    conditions:
+    - lastTransitionTime: "2026-08-14T14:56:11Z"
+      message: Quota reserved in ClusterQueue cluster-queue
+      observedGeneration: 1
+      reason: QuotaReserved
+      status: "True"
+      type: QuotaReserved
+    - lastTransitionTime: "2026-08-14T14:56:12Z"
+      message: The workload is admitted
+      observedGeneration: 1
+      reason: Admitted
+      status: "True"
+      type: Admitted
+    - lastTransitionTime: "2026-08-14T14:56:16Z"
+      message: All pods reached readiness and the workload is running
+      observedGeneration: 1
+      reason: Started
+      status: "True"
+      type: PodsReady
+```
+
+两道闸门在这里看得最清楚：`QuotaReserved`（manager 放行）→ `Admitted`（worker 接单）。
+
+---
+
+## 测试 2：JobSet
+
+**目标**：验证一个多 Pod 的 gang 工作负载被**整体**派发到同一个集群，不会被拆散。
+
+### 场景设计
+
+一个 JobSet，2 个 replicated Job，每个请求 500m CPU（总计 1 CPU）。
+
+### 分发策略
+
+同样是 **AllAtOnce**（全局配置，对所有工作负载类型生效）。分发策略是 Kueue 级别的配置，
+不区分框架。
+
+### 执行
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % ./scripts/run-demo-jobset.sh
+==> deleting demo workloads on mk-manager
+==> sweeping mk-worker1
+==> sweeping mk-worker2
+==> queues are empty:
+mk-worker1   0     0
+mk-worker2   0     0
+==> submitting a JobSet to mk-manager
+jobset.jobset.x-k8s.io/demo-jobset created
+==> spec.managedBy defaulted by the Kueue webhook on the manager:
+demo-jobset  managedBy=kueue.x-k8s.io/multikueue  suspend=false
+==> waiting for MultiKueue to dispatch...
+==> dispatched to mk-worker2
+
+==> MANAGER (mk-manager) — submitted here, but nothing executes here
+NAME                                 TERMINALSTATE   RESTARTS   COMPLETED   SUSPENDED   AGE
+jobset.jobset.x-k8s.io/demo-jobset                                          false       2s
+  pods on the manager (expected: none):
+  <none>
+
+==> MANAGER — Workloads: which worker cluster each one was dispatched to
+WORKLOAD                   ADMITTED   DISPATCHED-TO   MESSAGE
+jobset-demo-jobset-0e211   True       mk-worker2      The workload was admitted on "mk-worker2"
+
+==> WORKER (mk-worker1) — the Pods actually run here
+CLUSTERQUEUE    PENDING   ADMITTED
+cluster-queue   0         0
+
+==> WORKER (mk-worker2) — the Pods actually run here
+NAME                              STATUS    COMPLETIONS   DURATION   AGE
+job.batch/demo-jobset-workers-0   Running   0/1           2s         2s
+job.batch/demo-jobset-workers-1   Running   0/1           2s         2s
+NAME                                 TERMINALSTATE   RESTARTS   COMPLETED   SUSPENDED   AGE
+jobset.jobset.x-k8s.io/demo-jobset                   0                      false       2s
+NAME                            READY   STATUS              RESTARTS   AGE
+demo-jobset-workers-0-0-p44m7   0/1     ContainerCreating   0          2s
+demo-jobset-workers-1-0-9xqnm   0/1     ContainerCreating   0          2s
+CLUSTERQUEUE    PENDING   ADMITTED
+cluster-queue   0         1
+```
+
+### 结果解读
+
+| 观察点 | 输出 | 说明 |
+|---|---|---|
+| manager 上的 JobSet | 存在，`SUSPENDED false` | 只是个影子对象 |
+| manager 上的**子 Job** | 不存在 | JobSet 控制器因 `managedBy` 主动不干活 |
+| manager 上的 Pod | `<none>` | ✓ |
+| mk-worker2 | 2 个子 Job + 2 个 Pod | 整个 JobSet 完整落在**一个**集群 |
+| mk-worker1 | 空 | ✓ **gang 不会被跨集群拆散** |
+
+这是 MultiKueue 相比"把 Pod 撒到各个集群"的关键区别：**派发的最小单位是整个 Workload**，
+分布式训练需要的 Pod 间通信因此得以保证。
+
+`managedBy=kueue.x-k8s.io/multikueue` 在提交后 2 秒就被 webhook 打上了，我们的 YAML 里
+并没有写它：
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % grep -c managedBy examples/jobset.yaml
+0
+```
+
+---
+
+## 测试 3：RayJob
+
+**目标**：验证一个会**动态创建子资源**（RayCluster）的工作负载，其子资源只在目标 worker
+上被创建。
+
+### 场景设计
+
+一个 RayJob：head 500m/2Gi + 1 个 worker 500m/1Gi（合计 1 CPU / 3Gi，装得进 worker 的
+2 CPU / 4Gi 配额）。`shutdownAfterJobFinishes: true`，跑完自动拆掉 RayCluster 释放配额。
+
+### 分发策略
+
+仍是 **AllAtOnce**。
+
+### 执行
+
+脚本会先把 Ray 镜像预加载进两个 worker（177MB 的精简 Ray 镜像，比官方 `rayproject/ray`
+的数 GB 轻很多）：
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % ./scripts/run-demo-rayjob.sh
+==> deleting demo workloads on mk-manager
+==> sweeping mk-worker1
+==> sweeping mk-worker2
+==> queues are empty:
+mk-worker1   0     0
+mk-worker2   0     0
+==> pre-pulling us-central1-docker.pkg.dev/k8s-staging-images/kueue/ray-project-mini:0.0.4 on the host
+==> loading the Ray image into mk-worker1
+==> loading the Ray image into mk-worker2
+==> submitting a RayJob to mk-manager
+rayjob.ray.io/demo-rayjob created
+==> spec.managedBy defaulted by the Kueue webhook on the manager:
+demo-rayjob  managedBy=kueue.x-k8s.io/multikueue  suspend=
+==> waiting for MultiKueue to dispatch...
+==> dispatched to mk-worker2
+==> watching the RayCluster come up on the worker (Ctrl-C is safe)...
+  demo-rayjob-mm7f9-head-7zzgz                 0/1   Running       0     2s
+  demo-rayjob-mm7f9-small-group-worker-llslc   0/1   Init:0/1      0     2s
+
+==> MANAGER (mk-manager) — submitted here, but nothing executes here
+NAME                        JOB STATUS   DEPLOYMENT STATUS   RAY CLUSTER NAME    START TIME             END TIME   AGE
+rayjob.ray.io/demo-rayjob                Initializing        demo-rayjob-mm7f9   2026-08-14T14:55:38Z              3s
+  pods on the manager (expected: none):
+  <none>
+
+==> MANAGER — Workloads: which worker cluster each one was dispatched to
+WORKLOAD                   ADMITTED   DISPATCHED-TO   MESSAGE
+rayjob-demo-rayjob-a5a54   True       mk-worker2      The workload was admitted on "mk-worker2"
+
+==> WORKER (mk-worker1) — the Pods actually run here
+CLUSTERQUEUE    PENDING   ADMITTED
+cluster-queue   0         0
+
+==> WORKER (mk-worker2) — the Pods actually run here
+NAME                        JOB STATUS   DEPLOYMENT STATUS   RAY CLUSTER NAME    START TIME             END TIME   AGE
+rayjob.ray.io/demo-rayjob                Initializing        demo-rayjob-mm7f9   2026-08-14T14:55:38Z              2s
+NAME                                         READY   STATUS   RESTARTS   AGE
+demo-rayjob-mm7f9-head-7zzgz                 0/1     Running  0          2s
+demo-rayjob-mm7f9-small-group-worker-llslc   0/1     Init:0/1 0          2s
+CLUSTERQUEUE    PENDING   ADMITTED
+cluster-queue   0         1
+
+==> waiting for the RayJob to finish...
+==> final state on the manager (status synced back from the worker):
+NAME          JOB-STATUS   DEPLOYMENT   MANAGED-BY
+demo-rayjob   SUCCEEDED    Running      kueue.x-k8s.io/multikueue
+WORKLOAD                   FINISHED   RAN-ON
+rayjob-demo-rayjob-a5a54   <none>     mk-worker2
+  pods on the manager (expected: none):
+  No resources found in default namespace.
+```
+
+### 结果解读
+
+| 观察点 | 输出 | 说明 |
+|---|---|---|
+| manager 上的 RayJob | 存在，`RAY CLUSTER NAME` 有值 | 状态从 worker 同步回来的 |
+| manager 上的 **RayCluster Pod** | `<none>` | KubeRay operator 因 `managedBy` 不建 Pod |
+| mk-worker2 | head + worker Pod | RayCluster 只在这里被真正创建 |
+| manager 最终 `JOB-STATUS` | `SUCCEEDED` | **worker 上的执行结果同步回了 manager** |
+
+最后一行是 MultiKueue 状态同步的直接证明：用户只跟 manager 打交道，却能看到 worker 上的
+真实执行结果。
+
+### 观察 RayCluster 的生命周期
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-worker2 -n default get events --sort-by=.lastTimestamp | tail -8
+53s   Normal  CreatedService          rayjob/demo-rayjob    Created the service default/demo-rayjob-head-svc
+53s   Normal  CreatedRayJobSubmitter  rayjob/demo-rayjob    Created Kubernetes Job default/demo-rayjob
+52s   Normal  Started                 pod/demo-rayjob-mlv7m Container started
+43s   Normal  DeletedRayCluster       rayjob/demo-rayjob    Deleted cluster default/demo-rayjob-4sp5h
+43s   Normal  Killing                 pod/demo-rayjob-4sp5h-head-nmg2m  Stopping container ray-head
+43s   Normal  Completed               job/demo-rayjob       Job completed
+```
+
+`Job completed` → `DeletedRayCluster` 就是 `shutdownAfterJobFinishes: true` 在起作用，
+worker 的配额随之释放。
+
+---
+
+## 排错手册
+
+### 坑1: JobSet CRD 缺失导致连接失败
+
+**症状**：
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-manager get multikueuecluster \
+  -o custom-columns='CLUSTER:.metadata.name,ACTIVE:.status.conditions[?(@.type=="Active")].status,REASON:.status.conditions[?(@.type=="Active")].reason,MESSAGE:.status.conditions[?(@.type=="Active")].message'
+CLUSTER      ACTIVE   REASON                   MESSAGE
+mk-worker1   False    ClientConnectionFailed   no matches for kind "JobSet" in version "jobset.x-k8s.io/v1alpha2"
+mk-worker2   False    ClientConnectionFailed   no matches for kind "JobSet" in version "jobset.x-k8s.io/v1alpha2"
+
+CHECK              ACTIVE   MESSAGE
+multikueue-check   False    Inactive clusters: [mk-worker1 mk-worker2]
+```
+
+**原因**：Kueue 默认启用了 jobset / appwrapper / trainer / lws 等一堆集成，MultiKueue
+为每个启用的框架在 worker 上建 watch，worker 缺对应 CRD 就整体失败。
+
+**解决**：二选一
+
+1. 在**所有** worker 上装齐这些 operator；或者
+2. 把 `integrations.frameworks` 收窄到实际安装的那几个（本 demo 的做法，见
+   `manifests/kueue-config.yaml`），改完必须重启 controller：
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-manager apply -f manifests/kueue-config.yaml
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-manager -n kueue-system rollout restart deployment/kueue-controller-manager
+```
+
+### 坑2: manager 连不上 worker（kind 网络）
+
+**症状**：`Active=False`，MESSAGE 里是 `connection refused` 或 `i/o timeout`。
+
+**原因**：kubeconfig 里的 server 写成了 `https://127.0.0.1:<port>`。宿主机能通，manager
+的 Pod 通不了。
+
+**排查**：
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-manager -n kueue-system get secret mk-worker1-secret \
+  -o jsonpath='{.data.kubeconfig}' | base64 -d | grep server
+    server: https://172.19.0.3:6443
+```
+
+必须是 `172.x.x.x` 这种 docker 网络内地址。如果是 `127.0.0.1`，重跑 `./scripts/4-connect.sh`。
+
+### 坑3: RayJob head 容器 OOMKilled
+
+**症状**：head Pod `CrashLoopBackOff`，且**一行日志都没有**。
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-worker1 -n default get pod <head-pod> \
+  -o jsonpath='{.status.containerStatuses[0].lastState}'
+{"terminated":{"exitCode":137,"reason":"OOMKilled",...}}
+```
+
+**原因**：Ray head 内存给少了。`exitCode 137` = OOMKilled。
+
+**解决**：head 的 `limits.memory` 至少 4Gi（本 demo 给了 8Gi）。注意 `requests` 才是
+Kueue 配额账本上算的数，`limits` 不算 —— 所以可以 requests 给 2Gi、limits 给 8Gi，既不
+撑爆配额又不会 OOM。
+
+### 坑4: Ray object store 尺寸报错
+
+**症状**：
+
+```
+ValueError: Attempting to cap object store memory usage at 1146470 bytes,
+but the minimum allowed is 78643200 bytes.
+```
+
+**解决**：在 `rayStartParams` 里显式指定：
+
+```yaml
+rayStartParams:
+  object-store-memory: "134217728"
+```
+
+### 坑5: kind load docker-image 失败
+
+**症状**：
+
+```
+ERROR: failed to load image: ... ctr: content digest sha256:...: not found
+```
+
+**原因**：`kind load docker-image` 用 `--all-platforms` 重新导入，多架构镜像在本地只有
+当前平台的层，其他平台的 digest 找不到。
+
+**解决**：先 `docker save --platform` 存成单平台归档再导入：
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % docker save --platform linux/arm64 <image> -o image.tar
+gyliu-cary@Mac multikueue-minimal-demo % kind load image-archive image.tar --name mk-worker1
+```
+
+### 坑6: Workload 卡在 pending，worker 上什么都没有
+
+**排查顺序**：
+
+```console
+# 1. AdmissionCheck 是否 Active
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-manager get admissioncheck multikueue-check -o yaml | grep -A5 conditions
+
+# 2. worker 上是否有同名 namespace 和 LocalQueue（名字必须完全一致）
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-worker1 -n default get localqueue
+
+# 3. worker 的 ResourceFlavor 名字是否和 manager 一致
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-worker1 get resourceflavor
+
+# 4. worker 配额是否根本装不下这个 Workload
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-worker1 get clusterqueue cluster-queue -o yaml | grep -A20 "status:"
+
+# 5. 看 manager 的 Kueue 日志
+gyliu-cary@Mac multikueue-minimal-demo % kubectl --context kind-mk-manager -n kueue-system logs deployment/kueue-controller-manager --tail=100 | grep -i multikueue
+```
+
+### 通用状态检查
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % ./scripts/status.sh
+```
+
+---
+
+## 清理
+
+清掉工作负载但保留集群（方便反复做实验）：
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % ./scripts/clean-workloads.sh
+==> deleting demo workloads on mk-manager
+==> sweeping mk-worker1
+==> sweeping mk-worker2
+==> queues are empty:
+mk-worker1   0     0
+mk-worker2   0     0
+```
+
+删掉整个环境：
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % ./scripts/down.sh
+==> deleting cluster mk-manager
+Deleting cluster "mk-manager" ...
+==> deleting cluster mk-worker1
+Deleting cluster "mk-worker1" ...
+==> deleting cluster mk-worker2
+Deleting cluster "mk-worker2" ...
+==> torn down
+```
+
+等价手工命令：
+
+```console
+gyliu-cary@Mac multikueue-minimal-demo % kind delete clusters mk-manager mk-worker1 mk-worker2
+```

--- a/kueue/multikueue-minimal-demo/examples/jobs.yaml
+++ b/kueue/multikueue-minimal-demo/examples/jobs.yaml
@@ -1,0 +1,92 @@
+# Three plain batch/v1 Jobs — no CRD, no operator, nothing beyond Kueue.
+#
+# The only Kueue-specific bit is the queue-name label. Kueue's webhook suspends
+# the Job, and because cluster-queue carries a MultiKueue AdmissionCheck it also
+# stamps spec.managedBy=kueue.x-k8s.io/multikueue so the local Job controller
+# keeps its hands off — the Job only ever runs on a worker cluster.
+#
+# Each worker has 2 CPU of quota and each Job asks for 2 CPU, so two Jobs run
+# (one per worker) and the third waits.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: demo-job-1
+  namespace: default
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue
+spec:
+  parallelism: 1
+  completions: 1
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: sleeper
+          image: registry.k8s.io/e2e-test-images/agnhost:2.53
+          command: ["sh", "-c", "echo running on node $NODE_NAME; sleep 60"]
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          resources:
+            requests:
+              cpu: "2"
+              memory: 200Mi
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: demo-job-2
+  namespace: default
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue
+spec:
+  parallelism: 1
+  completions: 1
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: sleeper
+          image: registry.k8s.io/e2e-test-images/agnhost:2.53
+          command: ["sh", "-c", "echo running on node $NODE_NAME; sleep 60"]
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          resources:
+            requests:
+              cpu: "2"
+              memory: 200Mi
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: demo-job-3
+  namespace: default
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue
+spec:
+  parallelism: 1
+  completions: 1
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: sleeper
+          image: registry.k8s.io/e2e-test-images/agnhost:2.53
+          command: ["sh", "-c", "echo running on node $NODE_NAME; sleep 60"]
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          resources:
+            requests:
+              cpu: "2"
+              memory: 200Mi

--- a/kueue/multikueue-minimal-demo/examples/jobset.yaml
+++ b/kueue/multikueue-minimal-demo/examples/jobset.yaml
@@ -1,0 +1,40 @@
+# A JobSet dispatched through MultiKueue.
+#
+# Note there is NO spec.managedBy here: Kueue's webhook defaults it to
+# kueue.x-k8s.io/multikueue because the queue-name label points at a
+# ClusterQueue carrying a MultiKueue AdmissionCheck. That is what stops the
+# JobSet controller on the manager from creating any child Jobs locally.
+#
+# Total request: 2 replicas x 500m = 1 CPU, which fits in one worker's 2 CPU quota.
+apiVersion: jobset.x-k8s.io/v1alpha2
+kind: JobSet
+metadata:
+  name: demo-jobset
+  namespace: default
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue
+spec:
+  replicatedJobs:
+    - name: workers
+      replicas: 2
+      template:
+        spec:
+          parallelism: 1
+          completions: 1
+          backoffLimit: 0
+          template:
+            spec:
+              restartPolicy: Never
+              containers:
+                - name: sleeper
+                  image: registry.k8s.io/e2e-test-images/agnhost:2.53
+                  command: ["sh", "-c", "echo jobset member on $NODE_NAME; sleep 45"]
+                  env:
+                    - name: NODE_NAME
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: spec.nodeName
+                  resources:
+                    requests:
+                      cpu: 500m
+                      memory: 200Mi

--- a/kueue/multikueue-minimal-demo/examples/rayjob.yaml
+++ b/kueue/multikueue-minimal-demo/examples/rayjob.yaml
@@ -1,0 +1,73 @@
+# A RayJob dispatched through MultiKueue.
+#
+# As with the JobSet, spec.managedBy is defaulted to kueue.x-k8s.io/multikueue by
+# Kueue's webhook, so the KubeRay operator on the manager ignores this object and
+# creates no Ray pods there. The RayCluster is materialised on the worker only.
+#
+# shutdownAfterJobFinishes tears the RayCluster down once the entrypoint exits,
+# which releases the worker's quota.
+#
+# Quota accounting (this is what the worker ClusterQueue gates on — *requests*,
+# not limits): head 500m/2Gi + 1 worker 500m/1Gi = 1 CPU / 3Gi, which fits the
+# worker's 2 CPU / 4Gi quota.
+#
+# Note the memory: a Ray head under 2Gi gets OOMKilled (exit code 137) before it
+# writes a single log line, which looks like a MultiKueue failure but is not.
+apiVersion: ray.io/v1
+kind: RayJob
+metadata:
+  name: demo-rayjob
+  namespace: default
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue
+spec:
+  shutdownAfterJobFinishes: true
+  entrypoint: python -c "import ray; ray.init(); print('RAY NODES:', len(ray.nodes()))"
+  rayClusterSpec:
+    # Must match the Ray version baked into the image below.
+    rayVersion: "2.55.1"
+    headGroupSpec:
+      # Without an explicit object-store size Ray derives one from the container's
+      # cgroup and lands below its own 75MB floor, dying with:
+      #   ValueError: Attempting to cap object store memory usage at 1146470 bytes,
+      #   but the minimum allowed is 78643200 bytes.
+      rayStartParams:
+        object-store-memory: "134217728"
+      template:
+        spec:
+          containers:
+            - name: ray-head
+              image: us-central1-docker.pkg.dev/k8s-staging-images/kueue/ray-project-mini:0.0.4
+              resources:
+                requests:
+                  cpu: 500m
+                  memory: 2Gi
+                limits:
+                  cpu: "2"
+                  memory: 8Gi
+              ports:
+                - containerPort: 6379
+                  name: gcs-server
+                - containerPort: 8265
+                  name: dashboard
+                - containerPort: 10001
+                  name: client
+    workerGroupSpecs:
+      - groupName: small-group
+        replicas: 1
+        minReplicas: 1
+        maxReplicas: 1
+        rayStartParams:
+          object-store-memory: "134217728"
+        template:
+          spec:
+            containers:
+              - name: ray-worker
+                image: us-central1-docker.pkg.dev/k8s-staging-images/kueue/ray-project-mini:0.0.4
+                resources:
+                  requests:
+                    cpu: 500m
+                    memory: 1Gi
+                  limits:
+                    cpu: "1"
+                    memory: 2Gi

--- a/kueue/multikueue-minimal-demo/manifests/kueue-config.yaml
+++ b/kueue/multikueue-minimal-demo/manifests/kueue-config.yaml
@@ -1,0 +1,80 @@
+# Restricts Kueue's enabled integrations to exactly the frameworks this demo
+# installs: batch/Job, JobSet and KubeRay.
+#
+# WHY THIS IS REQUIRED, not just "nice to have":
+# Kueue ships with jobset, ray, appwrapper, trainer, lws, pod, deployment,
+# statefulset ... all enabled by default. For every enabled framework the
+# MultiKueue controller on the manager opens a watch against each worker
+# cluster. If a worker lacks that CRD the watch fails and the whole
+# MultiKueueCluster flips to Active=False with:
+#
+#   ClientConnectionFailed: no matches for kind "JobSet" in version "jobset.x-k8s.io/v1alpha2"
+#
+# So the rule is: the enabled framework list must exactly match the operators
+# actually installed on the workers.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kueue-manager-config
+  namespace: kueue-system
+data:
+  controller_manager_config.yaml: |
+    apiVersion: config.kueue.x-k8s.io/v1beta2
+    kind: Configuration
+    health:
+      healthProbeBindAddress: :8081
+    metrics:
+      bindAddress: :8443
+    webhook:
+      port: 9443
+    leaderElection:
+      leaderElect: true
+      resourceName: c1f6bfd2.kueue.x-k8s.io
+    controller:
+      groupKindConcurrency:
+        Job.batch: 5
+        Workload.kueue.x-k8s.io: 10
+        LocalQueue.kueue.x-k8s.io: 5
+        Cohort.kueue.x-k8s.io: 1
+        ClusterQueue.kueue.x-k8s.io: 5
+        ResourceFlavor.kueue.x-k8s.io: 1
+    clientConnection:
+      qps: 300
+      burst: 500
+    integrations:
+      frameworks:
+      - "batch/job"
+      - "jobset.x-k8s.io/jobset"
+      - "ray.io/rayjob"
+      - "ray.io/raycluster"
+      - "ray.io/rayservice"
+    multiKueue:
+      # DISPATCH STRATEGY. Two built-in dispatchers ship with Kueue:
+      #
+      #   kueue.x-k8s.io/multikueue-dispatcher-all-at-once   (default)
+      #     Nominates EVERY cluster in the MultiKueueConfig at the same time,
+      #     creates a remote Workload on each, and the first worker to admit
+      #     wins. The losing copies are deleted. Fastest time-to-start; costs a
+      #     brief burst of remote objects proportional to the cluster count.
+      #
+      #   kueue.x-k8s.io/multikueue-dispatcher-incremental
+      #     Nominates clusters in waves of `stepSize` (default 3), widening the
+      #     pool only if nobody admitted. Gentler on large fleets, and with the
+      #     MultiKueueIncrementalDispatcherRespectConfigOrder gate (beta, on by
+      #     default in v0.19) the waves follow the order in
+      #     MultiKueueConfig.spec.clusters, which makes it a preference list.
+      #
+      # A third option is any custom controller name — Kueue then only manages
+      # the remote copies and lets your controller pick the target clusters.
+      #
+      # This demo pins all-at-once explicitly. With only 2 workers it behaves the
+      # same as incremental, but stating it makes the knob visible.
+      dispatcherName: kueue.x-k8s.io/multikueue-dispatcher-all-at-once
+      # Only honoured by the incremental dispatcher; shown here for reference.
+      # incrementalDispatcherConfig:
+      #   stepSize: 1
+      #
+      # How long a workload stays Ready after losing contact with its worker.
+      workerLostTimeout: 15m
+      # How often orphaned remote objects are garbage-collected.
+      gcInterval: 1m

--- a/kueue/multikueue-minimal-demo/manifests/manager-multikueue.yaml
+++ b/kueue/multikueue-minimal-demo/manifests/manager-multikueue.yaml
@@ -1,0 +1,79 @@
+# Queue setup + MultiKueue wiring on the manager cluster.
+#
+# The chain is:
+#   ClusterQueue --(admissionChecksStrategy)--> AdmissionCheck
+#     --(parameters)--> MultiKueueConfig --(clusters)--> MultiKueueCluster
+#       --(kubeConfig Secret)--> the worker's API server
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  name: default-flavor
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ClusterQueue
+metadata:
+  name: cluster-queue
+spec:
+  namespaceSelector: {}
+  resourceGroups:
+    - coveredResources: ["cpu", "memory"]
+      flavors:
+        - name: default-flavor
+          resources:
+            - name: cpu
+              nominalQuota: 10
+            - name: memory
+              nominalQuota: 20Gi
+  # Attaching a MultiKueue AdmissionCheck is what turns this into a
+  # "delegating" queue: nothing runs here, admission is decided by a worker.
+  admissionChecksStrategy:
+    admissionChecks:
+      - name: multikueue-check
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: LocalQueue
+metadata:
+  name: user-queue
+  namespace: default
+spec:
+  clusterQueue: cluster-queue
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: AdmissionCheck
+metadata:
+  name: multikueue-check
+spec:
+  controllerName: kueue.x-k8s.io/multikueue
+  parameters:
+    apiGroup: kueue.x-k8s.io
+    kind: MultiKueueConfig
+    name: multikueue-config
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: MultiKueueConfig
+metadata:
+  name: multikueue-config
+spec:
+  clusters:
+    - mk-worker1
+    - mk-worker2
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: MultiKueueCluster
+metadata:
+  name: mk-worker1
+spec:
+  clusterSource:
+    kubeConfig:
+      locationType: Secret
+      location: mk-worker1-secret # Secret in kueue-system, key "kubeconfig"
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: MultiKueueCluster
+metadata:
+  name: mk-worker2
+spec:
+  clusterSource:
+    kubeConfig:
+      locationType: Secret
+      location: mk-worker2-secret

--- a/kueue/multikueue-minimal-demo/manifests/worker-multikueue-rbac.yaml
+++ b/kueue/multikueue-minimal-demo/manifests/worker-multikueue-rbac.yaml
@@ -1,0 +1,82 @@
+# Credentials the manager cluster uses to drive this worker.
+#
+# This is the upstream examples/multikueue/create-multikueue-kubeconfig.sh RBAC
+# narrowed to the frameworks this demo installs: batch/Job, JobSet and KubeRay.
+# Rules for Kubeflow, LeaderWorkerSet and AppWrapper are omitted because those
+# operators are not installed here.
+#
+# Rule of thumb: this list must cover every framework in
+# manifests/kueue-config.yaml, otherwise the manager's watch is rejected with a
+# 403 and the MultiKueueCluster goes Active=False.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: multikueue-sa
+  namespace: kueue-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: multikueue-sa-role
+rules:
+  # --- Kueue's own objects ---
+  - apiGroups: ["kueue.x-k8s.io"]
+    resources: ["workloads"]
+    verbs: ["create", "delete", "get", "list", "watch", "update", "patch"]
+  - apiGroups: ["kueue.x-k8s.io"]
+    resources: ["workloads/status"]
+    verbs: ["get", "update", "patch"]
+  - apiGroups: ["kueue.x-k8s.io"]
+    resources: ["clusterqueues", "localqueues"]
+    verbs: ["get", "list", "watch"]
+  # --- batch/Job ---
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["create", "delete", "get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs/status"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["create", "delete", "get", "list", "watch"]
+  # --- JobSet ---
+  - apiGroups: ["jobset.x-k8s.io"]
+    resources: ["jobsets"]
+    verbs: ["create", "delete", "get", "list", "watch"]
+  - apiGroups: ["jobset.x-k8s.io"]
+    resources: ["jobsets/status"]
+    verbs: ["get"]
+  # --- KubeRay ---
+  - apiGroups: ["ray.io"]
+    resources: ["rayjobs", "rayservices"]
+    verbs: ["create", "delete", "get", "list", "watch"]
+  - apiGroups: ["ray.io"]
+    resources: ["rayclusters"]
+    verbs: ["create", "delete", "get", "list", "watch", "update", "patch"]
+  - apiGroups: ["ray.io"]
+    resources: ["rayjobs/status", "rayclusters/status", "rayservices/status"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: multikueue-sa-crb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: multikueue-sa-role
+subjects:
+  - kind: ServiceAccount
+    name: multikueue-sa
+    namespace: kueue-system
+---
+# Long-lived token for the ServiceAccount. Since k8s 1.24 these are not created
+# automatically, so we request one explicitly.
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/service-account-token
+metadata:
+  name: multikueue-sa
+  namespace: kueue-system
+  annotations:
+    kubernetes.io/service-account.name: multikueue-sa

--- a/kueue/multikueue-minimal-demo/manifests/worker-queues.yaml
+++ b/kueue/multikueue-minimal-demo/manifests/worker-queues.yaml
@@ -1,0 +1,36 @@
+# Queue setup applied to EVERY worker cluster.
+#
+# MultiKueue mirrors a Workload onto the worker as-is, so the worker must have a
+# LocalQueue with the SAME name in the SAME namespace as the manager. Only the
+# quota differs: the worker's quota is what actually gates execution.
+#
+# Deliberately tight (2 CPU) so the demo shows jobs spreading across clusters:
+# the batch/Job example asks for 2 CPU each, so each worker can only run one.
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  name: default-flavor
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ClusterQueue
+metadata:
+  name: cluster-queue
+spec:
+  namespaceSelector: {}
+  resourceGroups:
+    - coveredResources: ["cpu", "memory"]
+      flavors:
+        - name: default-flavor
+          resources:
+            - name: cpu
+              nominalQuota: 2
+            - name: memory
+              nominalQuota: 4Gi
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: LocalQueue
+metadata:
+  name: user-queue
+  namespace: default
+spec:
+  clusterQueue: cluster-queue

--- a/kueue/multikueue-minimal-demo/scripts/0-create-clusters.sh
+++ b/kueue/multikueue-minimal-demo/scripts/0-create-clusters.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Create the three single-node kind clusters: one manager, two workers.
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+
+for cluster in "${ALL_CLUSTERS[@]}"; do
+  if kind get clusters 2>/dev/null | grep -qx "${cluster}"; then
+    log "cluster ${cluster} already exists, reusing"
+  else
+    log "creating cluster ${cluster}"
+    kind create cluster --name "${cluster}" --image "${NODE_IMAGE}" --wait 120s
+  fi
+done
+
+log "clusters ready:"
+kind get clusters

--- a/kueue/multikueue-minimal-demo/scripts/1-install-frameworks.sh
+++ b/kueue/multikueue-minimal-demo/scripts/1-install-frameworks.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Install the job frameworks (JobSet + KubeRay) on ALL three clusters.
+#
+# Why on the manager too? Kueue only enables an integration if the corresponding
+# CRD exists, and MultiKueue needs the manager to hold the "shadow" copy of the
+# JobSet/RayJob. Both operators honour spec.managedBy=kueue.x-k8s.io/multikueue,
+# so on the manager they see the object and deliberately do nothing — no Pods are
+# created there. (This requires JobSet >= v0.6.0 and KubeRay >= v1.3.1.)
+#
+# Run this BEFORE installing Kueue: Kueue evaluates which integrations to enable
+# at startup, so the CRDs must already exist.
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+
+log "adding the kuberay helm repo"
+helm repo add kuberay https://ray-project.github.io/kuberay-helm/ >/dev/null
+helm repo update kuberay >/dev/null
+
+for cluster in "${ALL_CLUSTERS[@]}"; do
+  context="$(ctx "${cluster}")"
+
+  log "installing JobSet ${JOBSET_VERSION} on ${cluster}"
+  kubectl --context "${context}" apply --server-side -f "${JOBSET_MANIFEST}"
+
+  log "installing KubeRay ${KUBERAY_VERSION} on ${cluster}"
+  helm --kube-context "${context}" upgrade --install kuberay-operator kuberay/kuberay-operator \
+    --version "${KUBERAY_VERSION}" \
+    --namespace "${KUBERAY_NAMESPACE}" --create-namespace --wait --timeout 5m
+done
+
+for cluster in "${ALL_CLUSTERS[@]}"; do
+  context="$(ctx "${cluster}")"
+  log "waiting for the JobSet controller on ${cluster}"
+  kubectl --context "${context}" -n jobset-system rollout status \
+    deployment/jobset-controller-manager --timeout=300s
+done
+
+log "framework CRDs now available:"
+for cluster in "${ALL_CLUSTERS[@]}"; do
+  echo "--- ${cluster}"
+  kubectl --context "$(ctx "${cluster}")" get crd \
+    jobsets.jobset.x-k8s.io rayjobs.ray.io rayclusters.ray.io rayservices.ray.io \
+    -o custom-columns='CRD:.metadata.name' --no-headers
+done

--- a/kueue/multikueue-minimal-demo/scripts/2-install-kueue.sh
+++ b/kueue/multikueue-minimal-demo/scripts/2-install-kueue.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Install Kueue on all three clusters and pin its enabled integrations.
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+
+for cluster in "${ALL_CLUSTERS[@]}"; do
+  context="$(ctx "${cluster}")"
+
+  log "installing Kueue ${KUEUE_VERSION} on ${cluster}"
+  kubectl --context "${context}" apply --server-side -f "${KUEUE_MANIFEST}"
+
+  # Must match the operators installed in step 1 — see manifests/kueue-config.yaml.
+  log "pinning enabled integrations on ${cluster}"
+  kubectl --context "${context}" apply -f "${MANIFESTS_DIR}/kueue-config.yaml"
+  kubectl --context "${context}" -n kueue-system rollout restart deployment/kueue-controller-manager
+done
+
+for cluster in "${ALL_CLUSTERS[@]}"; do
+  context="$(ctx "${cluster}")"
+  log "waiting for kueue-controller-manager on ${cluster}"
+  kubectl --context "${context}" -n kueue-system rollout status \
+    deployment/kueue-controller-manager --timeout=300s
+  wait_for_kueue_webhook "${context}"
+done
+
+log "enabled integrations (should list batch/job, jobset and the ray kinds):"
+kubectl --context "$(ctx "${MANAGER}")" -n kueue-system get cm kueue-manager-config \
+  -o jsonpath='{.data.controller_manager_config\.yaml}' | sed -n '/integrations:/,$p'

--- a/kueue/multikueue-minimal-demo/scripts/3-setup-workers.sh
+++ b/kueue/multikueue-minimal-demo/scripts/3-setup-workers.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Mirror the queue setup onto each worker cluster.
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+
+for cluster in "${WORKERS[@]}"; do
+  log "applying queues on ${cluster}"
+  # The Kueue webhook may need a few seconds after the pod is Ready.
+  for attempt in {1..12}; do
+    if kubectl --context "$(ctx "${cluster}")" apply -f "${MANIFESTS_DIR}/worker-queues.yaml"; then
+      break
+    fi
+    warn "webhook not ready yet on ${cluster}, retry ${attempt}/12"
+    sleep 5
+  done
+done
+
+log "worker queues:"
+for cluster in "${WORKERS[@]}"; do
+  echo "--- ${cluster}"
+  kubectl --context "$(ctx "${cluster}")" get clusterqueue,localqueue -A
+done

--- a/kueue/multikueue-minimal-demo/scripts/4-connect.sh
+++ b/kueue/multikueue-minimal-demo/scripts/4-connect.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Build a kubeconfig for each worker and store it as a Secret on the manager.
+#
+# THE kind GOTCHA: `kind get kubeconfig` points at https://127.0.0.1:<random-port>,
+# which is only reachable from the host. The Kueue pod on the manager needs an
+# address reachable from *inside* the docker network. All kind clusters share the
+# `kind` bridge network, so we use the worker control-plane container's IP on that
+# network. kubeadm puts that IP in the API server serving cert, so TLS still verifies.
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+
+mkdir -p "${GENERATED_DIR}"
+chmod 0700 "${GENERATED_DIR}"
+
+for cluster in "${WORKERS[@]}"; do
+  context="$(ctx "${cluster}")"
+
+  log "creating MultiKueue ServiceAccount on ${cluster}"
+  kubectl --context "${context}" apply -f "${MANIFESTS_DIR}/worker-multikueue-rbac.yaml"
+
+  log "waiting for the ServiceAccount token to be populated on ${cluster}"
+  for _ in {1..30}; do
+    token="$(kubectl --context "${context}" -n kueue-system get secret multikueue-sa \
+      -o jsonpath='{.data.token}' 2>/dev/null || true)"
+    [[ -n "${token}" ]] && break
+    sleep 2
+  done
+  if [[ -z "${token}" ]]; then
+    warn "token for ${cluster} was never populated"; exit 1
+  fi
+  token="$(echo "${token}" | base64 -d)"
+  ca="$(kubectl --context "${context}" -n kueue-system get secret multikueue-sa \
+    -o jsonpath='{.data.ca\.crt}')"
+
+  api_ip="$(docker inspect -f '{{.NetworkSettings.Networks.kind.IPAddress}}' "${cluster}-control-plane")"
+  if [[ -z "${api_ip}" ]]; then
+    warn "could not resolve the docker IP of ${cluster}-control-plane"; exit 1
+  fi
+  log "${cluster} API server reachable in-network at https://${api_ip}:6443"
+
+  kubeconfig="${GENERATED_DIR}/${cluster}.kubeconfig"
+  touch "${kubeconfig}"
+  chmod 0600 "${kubeconfig}"
+  cat > "${kubeconfig}" <<EOF
+apiVersion: v1
+kind: Config
+clusters:
+  - name: ${cluster}
+    cluster:
+      certificate-authority-data: ${ca}
+      server: https://${api_ip}:6443
+users:
+  - name: multikueue-sa
+    user:
+      token: ${token}
+contexts:
+  - name: ${cluster}
+    context:
+      cluster: ${cluster}
+      user: multikueue-sa
+current-context: ${cluster}
+EOF
+
+  log "storing ${cluster} kubeconfig as a Secret on ${MANAGER}"
+  kubectl --context "$(ctx "${MANAGER}")" -n kueue-system create secret generic \
+    "${cluster}-secret" --from-file=kubeconfig="${kubeconfig}" \
+    --dry-run=client -o yaml | kubectl --context "$(ctx "${MANAGER}")" apply -f -
+done
+
+log "connection secrets on the manager:"
+kubectl --context "$(ctx "${MANAGER}")" -n kueue-system get secret | grep -- '-secret' || true

--- a/kueue/multikueue-minimal-demo/scripts/5-setup-manager.sh
+++ b/kueue/multikueue-minimal-demo/scripts/5-setup-manager.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Apply the queue setup + MultiKueue wiring on the manager cluster.
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+
+context="$(ctx "${MANAGER}")"
+
+log "applying MultiKueue setup on ${MANAGER}"
+for attempt in {1..12}; do
+  if kubectl --context "${context}" apply -f "${MANIFESTS_DIR}/manager-multikueue.yaml"; then
+    break
+  fi
+  warn "webhook not ready yet on ${MANAGER}, retry ${attempt}/12"
+  sleep 5
+done
+
+log "waiting for both MultiKueueClusters to report Active"
+for _ in {1..30}; do
+  ready="$(kubectl --context "${context}" get multikueuecluster \
+    -o jsonpath='{range .items[*]}{.status.conditions[?(@.type=="Active")].status}{"\n"}{end}' \
+    | grep -c True || true)"
+  [[ "${ready}" == "${#WORKERS[@]}" ]] && break
+  sleep 5
+done
+
+kubectl --context "${context}" get multikueuecluster \
+  -o custom-columns='CLUSTER:.metadata.name,ACTIVE:.status.conditions[?(@.type=="Active")].status,REASON:.status.conditions[?(@.type=="Active")].reason,MESSAGE:.status.conditions[?(@.type=="Active")].message'
+echo
+kubectl --context "${context}" get admissioncheck multikueue-check \
+  -o custom-columns='CHECK:.metadata.name,ACTIVE:.status.conditions[?(@.type=="Active")].status,MESSAGE:.status.conditions[?(@.type=="Active")].message'

--- a/kueue/multikueue-minimal-demo/scripts/clean-workloads.sh
+++ b/kueue/multikueue-minimal-demo/scripts/clean-workloads.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Remove every demo workload from the manager and both workers, so each example
+# starts from an empty queue. Deleting on the manager normally cascades to the
+# workers; the worker-side sweep is a safety net.
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+
+mctx="$(ctx "${MANAGER}")"
+
+log "deleting demo workloads on ${MANAGER}"
+kubectl --context "${mctx}" -n default delete jobs,jobsets,rayjobs --all --ignore-not-found >/dev/null 2>&1 || true
+
+for cluster in "${WORKERS[@]}"; do
+  log "sweeping ${cluster}"
+  kubectl --context "$(ctx "${cluster}")" -n default delete jobs,jobsets,rayjobs --all --ignore-not-found >/dev/null 2>&1 || true
+done
+
+# Give the controllers a moment to release the quota.
+sleep 5
+log "queues are empty:"
+for cluster in "${WORKERS[@]}"; do
+  kubectl --context "$(ctx "${cluster}")" get clusterqueue cluster-queue \
+    -o custom-columns="CLUSTER:.metadata.name,PENDING:.status.pendingWorkloads,ADMITTED:.status.admittedWorkloads" --no-headers \
+    | sed "s|^cluster-queue|${cluster}|"
+done

--- a/kueue/multikueue-minimal-demo/scripts/common.sh
+++ b/kueue/multikueue-minimal-demo/scripts/common.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Shared configuration for the MultiKueue demo.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+DEMO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MANIFESTS_DIR="${DEMO_ROOT}/manifests"
+EXAMPLES_DIR="${DEMO_ROOT}/examples"
+GENERATED_DIR="${DEMO_ROOT}/.generated"
+
+# --- component versions -------------------------------------------------------
+# Kueue v0.19.1 pins jobset v0.12.0 and kuberay v1.6.2 in its go.mod, so these
+# three versions are known to work together.
+KUEUE_VERSION="${KUEUE_VERSION:-v0.19.1}"
+KUEUE_MANIFEST="https://github.com/kubernetes-sigs/kueue/releases/download/${KUEUE_VERSION}/manifests.yaml"
+
+JOBSET_VERSION="${JOBSET_VERSION:-v0.12.0}"
+JOBSET_MANIFEST="https://github.com/kubernetes-sigs/jobset/releases/download/${JOBSET_VERSION}/manifests.yaml"
+
+KUBERAY_VERSION="${KUBERAY_VERSION:-1.6.2}"
+KUBERAY_NAMESPACE="${KUBERAY_NAMESPACE:-kuberay-system}"
+
+# Slim Ray image maintained by the Kueue project for tests. The real
+# rayproject/ray image is multiple GB, which is painful to pull into 3 clusters.
+RAY_IMAGE="${RAY_IMAGE:-us-central1-docker.pkg.dev/k8s-staging-images/kueue/ray-project-mini:0.0.4}"
+
+# kind v0.31.0 default node image. k8s >= 1.32 enables the JobManagedBy feature
+# gate by default, which MultiKueue needs to delegate batch/Jobs.
+NODE_IMAGE="${NODE_IMAGE:-kindest/node:v1.35.0@sha256:452d707d4862f52530247495d180205e029056831160e22870e37e3f6c1ac31f}"
+
+# --- clusters -----------------------------------------------------------------
+MANAGER="${MANAGER:-mk-manager}"
+WORKERS=("${WORKER1:-mk-worker1}" "${WORKER2:-mk-worker2}")
+ALL_CLUSTERS=("${MANAGER}" "${WORKERS[@]}")
+
+# kubectl context name kind assigns to a cluster.
+ctx() { echo "kind-$1"; }
+
+log()  { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m!!\033[0m %s\n' "$*"; }
+
+# Wait until the Kueue webhook Service has ready endpoints. Applying a Kueue CR
+# before this point fails with "connection refused" / "no endpoints available".
+wait_for_kueue_webhook() {
+  local context="$1"
+  for _ in {1..60}; do
+    if [[ -n "$(kubectl --context "${context}" -n kueue-system get endpointslice \
+      -l kubernetes.io/service-name=kueue-webhook-service \
+      -o jsonpath='{.items[*].endpoints[*].addresses[0]}' 2>/dev/null)" ]]; then
+      return 0
+    fi
+    sleep 2
+  done
+  warn "kueue webhook endpoints never became ready on ${context}"
+  return 1
+}

--- a/kueue/multikueue-minimal-demo/scripts/ctx.sh
+++ b/kueue/multikueue-minimal-demo/scripts/ctx.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Switch the current kubectl context between the demo clusters.
+#
+#   ./scripts/ctx.sh              # list contexts and show the current one
+#   ./scripts/ctx.sh manager      # switch to kind-mk-manager
+#   ./scripts/ctx.sh worker1      # switch to kind-mk-worker1
+#   ./scripts/ctx.sh worker2      # switch to kind-mk-worker2
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+
+target="${1:-}"
+
+if [[ -z "${target}" ]]; then
+  log "demo contexts (* = current):"
+  kubectl config get-contexts -o name | grep -E "kind-(${MANAGER}|${WORKERS[0]}|${WORKERS[1]})$" | while read -r c; do
+    if [[ "${c}" == "$(kubectl config current-context 2>/dev/null)" ]]; then
+      echo "  * ${c}"
+    else
+      echo "    ${c}"
+    fi
+  done
+  echo
+  echo "usage: $0 <manager|worker1|worker2>"
+  exit 0
+fi
+
+case "${target}" in
+  manager|mgr|m)  cluster="${MANAGER}" ;;
+  worker1|w1|1)   cluster="${WORKERS[0]}" ;;
+  worker2|w2|2)   cluster="${WORKERS[1]}" ;;
+  *)              warn "unknown target '${target}' (expected manager|worker1|worker2)"; exit 1 ;;
+esac
+
+kubectl config use-context "$(ctx "${cluster}")"
+log "now pointing at ${cluster}"
+kubectl get nodes

--- a/kueue/multikueue-minimal-demo/scripts/down.sh
+++ b/kueue/multikueue-minimal-demo/scripts/down.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Delete all three kind clusters and the generated kubeconfigs.
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+
+for cluster in "${ALL_CLUSTERS[@]}"; do
+  if kind get clusters 2>/dev/null | grep -qx "${cluster}"; then
+    log "deleting cluster ${cluster}"
+    kind delete cluster --name "${cluster}"
+  fi
+done
+
+rm -rf "${GENERATED_DIR}"
+log "torn down"

--- a/kueue/multikueue-minimal-demo/scripts/run-demo-job.sh
+++ b/kueue/multikueue-minimal-demo/scripts/run-demo-job.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Example 1 — batch/v1 Job.
+# Submits 3 Jobs of 2 CPU each against workers that hold 2 CPU of quota, so two
+# get dispatched (one per worker) and the third stays pending.
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+
+"${DEMO_ROOT}/scripts/clean-workloads.sh"
+
+log "submitting 3 batch/Jobs to ${MANAGER}"
+kubectl --context "$(ctx "${MANAGER}")" apply -f "${EXAMPLES_DIR}/jobs.yaml"
+
+log "waiting for MultiKueue to dispatch..."
+for _ in {1..40}; do
+  admitted="$(kubectl --context "$(ctx "${MANAGER}")" -n default get workloads \
+    -o jsonpath='{range .items[*]}{.status.conditions[?(@.type=="Admitted")].status}{"\n"}{end}' \
+    | grep -c True || true)"
+  [[ "${admitted}" -ge 2 ]] && break
+  sleep 5
+done
+
+exec "${DEMO_ROOT}/scripts/status.sh"

--- a/kueue/multikueue-minimal-demo/scripts/run-demo-jobset.sh
+++ b/kueue/multikueue-minimal-demo/scripts/run-demo-jobset.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Example 2 — JobSet.
+# One JobSet with 2 replicated Jobs. MultiKueue dispatches the whole JobSet to a
+# single worker; the JobSet controller there creates the child Jobs and Pods.
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+
+"${DEMO_ROOT}/scripts/clean-workloads.sh"
+
+log "submitting a JobSet to ${MANAGER}"
+kubectl --context "$(ctx "${MANAGER}")" apply -f "${EXAMPLES_DIR}/jobset.yaml"
+
+log "spec.managedBy defaulted by the Kueue webhook on the manager:"
+sleep 2
+kubectl --context "$(ctx "${MANAGER}")" -n default get jobset demo-jobset \
+  -o jsonpath='{.metadata.name}{"  managedBy="}{.spec.managedBy}{"  suspend="}{.spec.suspend}{"\n"}'
+
+log "waiting for MultiKueue to dispatch..."
+for _ in {1..40}; do
+  target="$(kubectl --context "$(ctx "${MANAGER}")" -n default get workloads \
+    -o jsonpath='{.items[0].status.clusterName}' 2>/dev/null || true)"
+  [[ -n "${target}" ]] && break
+  sleep 5
+done
+[[ -n "${target:-}" ]] && log "dispatched to ${target}"
+
+exec "${DEMO_ROOT}/scripts/status.sh"

--- a/kueue/multikueue-minimal-demo/scripts/run-demo-rayjob.sh
+++ b/kueue/multikueue-minimal-demo/scripts/run-demo-rayjob.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Example 3 — RayJob.
+# MultiKueue dispatches the RayJob to one worker; the KubeRay operator there
+# creates the RayCluster (head + 1 worker pod) and runs the entrypoint.
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+
+"${DEMO_ROOT}/scripts/clean-workloads.sh"
+
+# The Ray image is ~1GB; pre-loading it avoids the Pods sitting in
+# ContainerCreating for minutes on each worker.
+if [[ "${SKIP_IMAGE_PRELOAD:-false}" != "true" ]]; then
+  log "pre-pulling ${RAY_IMAGE} on the host"
+  docker pull --platform "linux/$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')" "${RAY_IMAGE}" >/dev/null
+
+  # `kind load docker-image` re-imports with --all-platforms, which fails for a
+  # multi-arch manifest whose other platforms are not in the local store:
+  #   ctr: content digest sha256:...: not found
+  # `docker save --platform` writes a single-platform archive, which imports cleanly.
+  mkdir -p "${GENERATED_DIR}"
+  archive="${GENERATED_DIR}/ray-mini.tar"
+  [[ -f "${archive}" ]] || docker save --platform "linux/$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')" \
+    "${RAY_IMAGE}" -o "${archive}"
+  for cluster in "${WORKERS[@]}"; do
+    log "loading the Ray image into ${cluster}"
+    kind load image-archive "${archive}" --name "${cluster}"
+  done
+fi
+
+log "submitting a RayJob to ${MANAGER}"
+kubectl --context "$(ctx "${MANAGER}")" apply -f "${EXAMPLES_DIR}/rayjob.yaml"
+
+log "spec.managedBy defaulted by the Kueue webhook on the manager:"
+sleep 2
+kubectl --context "$(ctx "${MANAGER}")" -n default get rayjob demo-rayjob \
+  -o jsonpath='{.metadata.name}{"  managedBy="}{.spec.managedBy}{"  suspend="}{.spec.suspend}{"\n"}'
+
+log "waiting for MultiKueue to dispatch..."
+for _ in {1..40}; do
+  target="$(kubectl --context "$(ctx "${MANAGER}")" -n default get workloads \
+    -o jsonpath='{.items[0].status.clusterName}' 2>/dev/null || true)"
+  [[ -n "${target}" ]] && break
+  sleep 5
+done
+[[ -n "${target:-}" ]] && log "dispatched to ${target}"
+
+log "watching the RayCluster come up on the worker (Ctrl-C is safe)..."
+for _ in {1..12}; do
+  pods="$(kubectl --context "$(ctx "${target:-${WORKERS[0]}}")" -n default get pods --no-headers 2>/dev/null || true)"
+  [[ -n "${pods}" ]] && { echo "${pods}" | sed 's/^/  /'; break; }
+  sleep 5
+done
+
+"${DEMO_ROOT}/scripts/status.sh"
+
+log "waiting for the RayJob to finish..."
+for _ in {1..60}; do
+  jobstatus="$(kubectl --context "$(ctx "${MANAGER}")" -n default get rayjob demo-rayjob \
+    -o jsonpath='{.status.jobStatus}' 2>/dev/null || true)"
+  [[ "${jobstatus}" == "SUCCEEDED" || "${jobstatus}" == "FAILED" ]] && break
+  sleep 5
+done
+
+log "final state on the manager (status synced back from the worker):"
+kubectl --context "$(ctx "${MANAGER}")" -n default get rayjob demo-rayjob \
+  -o custom-columns='NAME:.metadata.name,JOB-STATUS:.status.jobStatus,DEPLOYMENT:.status.jobDeploymentStatus,MANAGED-BY:.spec.managedBy'
+kubectl --context "$(ctx "${MANAGER}")" -n default get workloads \
+  -o custom-columns='WORKLOAD:.metadata.name,FINISHED:.status.conditions[?(@.type=="Finished")].status,RAN-ON:.status.clusterName'
+echo "  pods on the manager (expected: none):"
+kubectl --context "$(ctx "${MANAGER}")" -n default get pods 2>&1 | sed 's/^/  /'

--- a/kueue/multikueue-minimal-demo/scripts/status.sh
+++ b/kueue/multikueue-minimal-demo/scripts/status.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Show where workloads were submitted vs. where they are actually running.
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+
+mctx="$(ctx "${MANAGER}")"
+
+echo
+log "MANAGER (${MANAGER}) — submitted here, but nothing executes here"
+kubectl --context "${mctx}" -n default get jobs,jobsets,rayjobs 2>/dev/null | grep -v '^$' || true
+echo "  pods on the manager (expected: none):"
+kubectl --context "${mctx}" -n default get pods --no-headers 2>/dev/null | sed 's/^/  /' || true
+[[ -z "$(kubectl --context "${mctx}" -n default get pods --no-headers 2>/dev/null)" ]] && echo "  <none>"
+
+echo
+log "MANAGER — Workloads: which worker cluster each one was dispatched to"
+kubectl --context "${mctx}" -n default get workloads \
+  -o custom-columns='WORKLOAD:.metadata.name,ADMITTED:.status.conditions[?(@.type=="Admitted")].status,DISPATCHED-TO:.status.clusterName,MESSAGE:.status.admissionChecks[0].message' 2>/dev/null || true
+
+for cluster in "${WORKERS[@]}"; do
+  echo
+  log "WORKER (${cluster}) — the Pods actually run here"
+  kubectl --context "$(ctx "${cluster}")" -n default get jobs,jobsets,rayjobs 2>/dev/null | grep -v '^$' || true
+  kubectl --context "$(ctx "${cluster}")" -n default get pods 2>/dev/null || true
+  kubectl --context "$(ctx "${cluster}")" get clusterqueue cluster-queue \
+    -o custom-columns='CLUSTERQUEUE:.metadata.name,PENDING:.status.pendingWorkloads,ADMITTED:.status.admittedWorkloads' 2>/dev/null || true
+done
+echo

--- a/kueue/multikueue-minimal-demo/scripts/up.sh
+++ b/kueue/multikueue-minimal-demo/scripts/up.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# One-shot: build the whole environment. Run the run-demo-*.sh scripts afterwards.
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+
+"${DEMO_ROOT}/scripts/0-create-clusters.sh"
+"${DEMO_ROOT}/scripts/1-install-frameworks.sh"
+"${DEMO_ROOT}/scripts/2-install-kueue.sh"
+"${DEMO_ROOT}/scripts/3-setup-workers.sh"
+"${DEMO_ROOT}/scripts/4-connect.sh"
+"${DEMO_ROOT}/scripts/5-setup-manager.sh"
+
+log "environment ready. Now try:"
+echo "  ./scripts/run-demo-job.sh      # example 1 — batch/v1 Job"
+echo "  ./scripts/run-demo-jobset.sh   # example 2 — JobSet"
+echo "  ./scripts/run-demo-rayjob.sh   # example 3 — RayJob"


### PR DESCRIPTION
A 3-cluster MultiKueue demo running entirely on kind: one manager plus two workers. No OCM, no Karmada, no ArgoCD — MultiKueue is a complete multi-cluster scheduler on its own, and the only link between clusters is a kubeconfig.

### What's here

- `scripts/` — numbered setup steps (`0-create-clusters` → `5-setup-manager`), `up`/`down`, and per-workload demo runners
- `manifests/` — Kueue config, MultiKueue manager wiring, worker RBAC + queues
- `examples/` — batch/Job, JobSet and RayJob workloads
- `README` + `WALKTHROUGH`, both with zh-CN versions

### Versions

Kueue v0.19.1 / JobSet v0.12.0 / KubeRay v1.6.2 — the exact combination Kueue pins in its `go.mod` and validates in upstream e2e — on kind v0.31.0 with k8s v1.35.0. The `k8s >= 1.32` floor comes from the `JobManagedBy` feature gate that MultiKueue relies on.

Generated kubeconfigs and image tarballs are gitignored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a complete MultiKueue minimal demo for three Kubernetes clusters.
  * Added example workloads for batch Jobs, JobSets, and RayJobs.
  * Added automated setup, cluster connection, demo execution, status, cleanup, and teardown scripts.
  * Added manager and worker queue, quota, dispatch, and access configuration.
* **Documentation**
  * Added comprehensive English and Chinese quick-start guides and walkthroughs.
  * Included architecture, workflow, verification, troubleshooting, compatibility, and cleanup instructions.
* **Chores**
  * Updated ignore rules for generated files and kubeconfig artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->