### PR TITLE
explain the multikueue dispatch race in the demo README

### DIFF
--- a/kueue/multikueue-minimal-demo/README.md
+++ b/kueue/multikueue-minimal-demo/README.md
@@ -168,15 +168,85 @@ and that gate is only enabled by default from 1.32 onwards.
    │                       ├───────────────────────────>│ ✗              │
 ```
 
+### Steps ⑤–⑦ in detail — why only one worker runs it
+
+Step ⑤ raises the obvious question: *if the Workload is copied to **both** workers, why
+doesn't it run twice?* The answer is that **the thing being copied cannot run anything.**
+
+#### ⑤ The manager copies the Workload, not the Job
+
+A `Workload` is a queueing record — a request for quota. Nothing in Kubernetes creates pods
+from a Workload. Pods exist only because a **Job / JobSet / RayJob** object exists and its
+controller unsuspends it.
+
+At step ⑤ the manager creates **only the Workload copy** on w1 and on w2. Neither worker has
+a Job yet. So there is nothing that *could* run twice — the two copies are two competing
+**bids for quota**, not two running workloads. The real Job is created exactly once, at ⑧,
+after the race has already been settled.
+
+This is why duplicate execution is *structurally impossible* rather than merely unlikely: it
+does not depend on anyone winning a race quickly enough.
+
+#### ⑥ Each worker admits on its own, knowing nothing about the other
+
+Each worker runs plain, unmodified Kueue. Its scheduler sees a new Workload in its local
+ClusterQueue and admits it when local quota allows — the exact same code path as a
+single-cluster install. **A worker does not know the manager exists, does not know the other
+worker exists, and does not know it is in a race.** There is no coordination, no lock, no
+consensus protocol between workers.
+
+So "w1 admits FIRST" means nothing more than: w1's scheduler happened to set `Admitted=True`
+on its local copy before w2 did. In this demo both workers are idle and identically sized, so
+the winner is genuinely arbitrary — re-run the demo and it may well be w2.
+
+#### How does the manager know that w1 won?
+
+**The manager watches the workers; the workers never report back.** For each worker the
+manager holds a remote client built from the kubeconfig stored in the `mk-workerN-secret`
+Secret (created by `scripts/4-connect.sh`), and the MultiKueue AdmissionCheck controller
+**watches the remote Workload copies over that connection**.
+
+The direction is the whole trick. Nothing is pushed from worker to manager, so workers need
+no agent, no registration, no awareness of the federation — which is precisely why this works
+with a kubeconfig and no multi-cluster management platform.
+
+When that watch reports a remote copy carrying `Admitted=True`, the manager declares that
+copy's cluster the winner.
+
+#### ⑦ The winner is latched exactly once
+
+On learning w1 admitted, the manager does three things to its **local** Workload and to the
+losers:
+
+1. writes `status.clusterName: mk-worker1` — **this field is immutable once set**;
+2. sets the `multikueue-check` AdmissionCheck to `Ready`;
+3. **deletes the Workload copy on w2**, which releases the quota w2 had tentatively reserved
+   so a different Workload can use it.
+
+The immutability in (1) is what makes the race safe. If both workers admit before the manager
+reconciles — entirely possible — the manager still picks exactly **one**, the first its watch
+reports. The second observation tries to write a field that is already set, and is simply
+dropped. There is no window in which two winners exist.
+
+Only then does ⑧ create the real Job, on w1 alone, labelled with
+`kueue.x-k8s.io/prebuilt-workload-name` pointing at the copy that was already admitted — so
+w1's Kueue binds the Job to that existing admission instead of creating a second Workload and
+queueing all over again.
+
+> **Note:** this "copy to everyone, first to admit wins" behaviour is specific to the
+> **AllAtOnce** dispatcher, which this demo configures in `manifests/kueue-config.yaml`. The
+> `Incremental` dispatcher instead nominates a subset of clusters at a time and widens the set
+> on a timer — fewer wasted remote objects, slower to find a cluster with free quota.
+
 ### Observed Workload status
 
 ```yaml
 status:
-  clusterName: mk-worker2            # where it ran (immutable once set)
+  clusterName: mk-worker1            # where it ran (immutable once set)
   admissionChecks:
   - name: multikueue-check
     state: Ready
-    message: The workload was admitted on "mk-worker2"
+    message: The workload was admitted on "mk-worker1"
   conditions:
   - type: QuotaReserved              # GATE #1 — manager let it through
     status: "True"

--- a/kueue/multikueue-minimal-demo/README.zh-CN.md
+++ b/kueue/multikueue-minimal-demo/README.zh-CN.md
@@ -163,15 +163,74 @@ MultiKueue 环境，并跑通 **batch/Job、JobSet、RayJob** 三种工作负载
    │                       ├───────────────────────────>│ ✗              │
 ```
 
+### ⑤～⑦ 详解 —— 为什么只有一个 worker 会真正跑
+
+第 ⑤ 步会让人立刻产生一个疑问：*既然 Workload 被复制到了 w1 和 w2 **两边**，为什么不会跑两遍？*
+答案是：**被复制过去的那个东西，根本跑不起来任何东西。**
+
+#### ⑤ manager 复制的是 Workload，不是 Job
+
+`Workload` 只是一条排队记录 —— 一次配额申请。Kubernetes 里没有任何控制器会根据 Workload 去创建
+Pod。Pod 之所以存在，只可能是因为有一个 **Job / JobSet / RayJob** 对象，并且它的控制器把它
+unsuspend 了。
+
+第 ⑤ 步 manager 在 w1 和 w2 上创建的**只有 Workload 副本**，两个 worker 上都还没有 Job。所以
+根本不存在"可能跑两遍"的东西：这两份副本是两次互相竞争的**配额投标**，而不是两个正在运行的任务。
+真正的 Job 只会被创建一次，在第 ⑧ 步，也就是竞争已经分出胜负之后。
+
+所以重复执行是**结构上不可能**，而不是"概率很小"—— 它不依赖于谁抢得够不够快。
+
+#### ⑥ 每个 worker 各自独立 admit，彼此完全不知情
+
+每个 worker 上跑的都是原生、未经改造的 Kueue。它的调度器看到本地 ClusterQueue 里来了一个新
+Workload，本地配额够就 admit —— 和单集群 Kueue 走的是完全相同的代码路径。**worker 不知道
+manager 的存在，不知道另一个 worker 的存在，也不知道自己正在参加一场竞争。** worker 之间没有任何
+协调、没有锁、没有共识协议。
+
+因此"w1 先 admit"的含义仅仅是：w1 的调度器碰巧比 w2 先把自己那份副本置为 `Admitted=True`。本
+demo 里两个 worker 都是空闲的、配额也完全相同，所以谁赢纯属偶然 —— 重跑一次很可能就变成 w2。
+
+#### manager 是怎么知道 w1 赢了的？
+
+**是 manager 主动去看 worker，worker 从不向 manager 汇报。** manager 为每个 worker 持有一个远程
+client，用的是 `mk-workerN-secret` 这个 Secret 里存的 kubeconfig（由 `scripts/4-connect.sh`
+创建）；MultiKueue 的 AdmissionCheck 控制器**通过这条连接 watch 远程的 Workload 副本**。
+
+方向是这里的关键。没有任何东西从 worker 推给 manager，所以 worker 不需要装 agent、不需要注册、
+甚至不需要意识到自己身处一个联邦里 —— 这正是"一个 kubeconfig 就够，不需要任何多集群管理平台"
+能够成立的原因。
+
+当这个 watch 观测到某份远程副本带上了 `Admitted=True`，manager 就判定该副本所在的集群胜出。
+
+#### ⑦ 胜者只会被锁定一次
+
+确认 w1 admit 之后，manager 对自己**本地**那份 Workload 以及落败方做三件事：
+
+1. 写入 `status.clusterName: mk-worker1` —— **这个字段一旦设置就不可变**；
+2. 把 `multikueue-check` 这个 AdmissionCheck 置为 `Ready`；
+3. **删除 w2 上的那份 Workload 副本**，从而释放 w2 已经临时占住的配额，让别的 Workload 能用。
+
+第 (1) 条的不可变性就是这场竞争之所以安全的原因。如果两个 worker 在 manager reconcile 之前就都
+admit 了（完全可能发生），manager 依然只会选**一个** —— watch 最先报上来的那个；第二次观测想去写
+一个已经被写过的字段，会被直接丢弃。不存在"同时有两个胜者"的时间窗口。
+
+到这时才轮到第 ⑧ 步：只在 w1 上创建真正的 Job，并打上
+`kueue.x-k8s.io/prebuilt-workload-name` 标签指向那份已经被 admit 的副本 —— 这样 w1 的 Kueue 会
+把这个 Job 绑定到已有的 admission 上，而不是再新建一个 Workload 重新排一遍队。
+
+> **注意：**"复制给所有候选、谁先 admit 谁赢"这套行为是 **AllAtOnce** 分发器特有的，本 demo 在
+> `manifests/kueue-config.yaml` 里配置的就是它。而 `Incremental` 分发器则是一次只提名一部分集群，
+> 再按定时器逐步扩大范围 —— 产生的无用远程对象更少，但找到有空闲配额的集群更慢。
+
 ### 实际观测到的 Workload 状态
 
 ```yaml
 status:
-  clusterName: mk-worker2            # ← 最终跑在哪个集群（一旦设置就不可变）
+  clusterName: mk-worker1            # ← 最终跑在哪个集群（一旦设置就不可变）
   admissionChecks:
   - name: multikueue-check
     state: Ready
-    message: The workload was admitted on "mk-worker2"
+    message: The workload was admitted on "mk-worker1"
   conditions:
   - type: QuotaReserved              # ← 闸门①：manager 配额通过
     status: "True"


### PR DESCRIPTION
Follow-up to #398.

The workflow diagram walked through steps ⑤–⑦ but skipped the part that actually confuses people: **if the Workload is copied to both workers, why doesn't it run twice — and how does the manager find out who won?**

### New "Steps ⑤–⑦ in detail" section

- **Why it can't run twice** — what gets copied at ⑤ is the *Workload*, not the Job. Nothing creates pods from a Workload, and neither worker has a Job yet, so the two copies are competing *bids for quota*. The real Job is created once, at ⑧, after the race is settled. Duplicate execution is structurally impossible, not raced away.
- **Why only w1** — each worker runs plain single-cluster Kueue and knows nothing about the manager, the other worker, or the race. The winner is genuinely arbitrary between two idle, identically-sized workers.
- **How the manager knows** — it *watches* the remote copies over the worker kubeconfig in `mk-workerN-secret`; workers never call back. That direction is why no agent, registration, or multi-cluster platform is required.
- **Why the race is safe** — `status.clusterName` is immutable once set, so a double admission still produces exactly one winner; the loser's copy is deleted to release its tentatively-reserved quota. Plus what `prebuilt-workload-name` is for at ⑧.
- A note that this "copy to everyone, first to admit wins" shape is specific to the **AllAtOnce** dispatcher, contrasted with `Incremental`.

### Fix

The sample Workload status showed `clusterName: mk-worker2` while the diagram directly above it had **w1** winning. Now consistent at `mk-worker1`.

Left alone deliberately: the 3-Job quota example (w1/w2 split is the point there) and the `WALKTHROUGH.md` terminal capture, which is real recorded output from an actual run.

Both `README.md` and `README.zh-CN.md` updated in parallel.