### PR TITLE
Llm d gpu kind demo

### DIFF
--- a/llm-d/llm-d-full-demo/README.md
+++ b/llm-d/llm-d-full-demo/README.md
@@ -12,6 +12,11 @@ This document records a **no-GPU, Apple-Silicon (arm64) Kind** deployment of llm
 > Gateway (agentgateway / Istio) propagates the trace context to the EPP `ext_proc`,
 > which the EPP adopts (PR #1514) — so the gateway hop and the EPP land in **one** trace.
 
+> **New to llm-d?** [`docs/request-lifecycle-zh.md`](docs/request-lifecycle-zh.md) is a
+> beginner-oriented walkthrough (Chinese) of exactly what happens, component by component
+> and CRD/CR field by field, for one prompt request — captured live against this same
+> 2026-08-28 re-run.
+
 ---
 
 ## 1. System Architecture / 系统架构
@@ -800,3 +805,27 @@ this document was re-executed. What changed since the previous run:
 | **2 model-server replicas** | Turns the prefix scorer from a formality into a visible decision (`top_scores=[7,4]`). Required cutting `router.tokenizer.resources` (4 CPU/8Gi default) and the model-server requests, or the second replica cannot schedule. |
 | **P/D pool** (Step 3.12) | A fourth service and the richest trace in the demo (21 spans): disagg profile scheduling + the sidecar's prefill/decode legs. Runs on `llm-d-inference-sim` because CPU vLLM has no NIXL. |
 | Second router release `llm-d-pd` | An EPP runs one plugin config, so P/D needs its own release; the chart namespaces by release name and the two pools coexist on one Gateway via a header-matched `HTTPRoute`. |
+
+---
+
+## Re-run log — 2026-08-28 against `main`
+
+Full clean re-run (fresh Kind cluster, all three images rebuilt from `upstream/main`:
+`llm-d-router@ead3e86f`, `llm-d-inference-payload-processor@ff85c3d`). Two **breaking**
+upstream changes had to be fixed to get a healthy cluster; everything else in Steps 3.1–3.12
+worked as documented.
+
+| Area | Change |
+| --- | --- |
+| **Router Gateway chart renamed** | `oci://ghcr.io/llm-d/charts/llm-d-router-gateway-dev` now 403s (artifact no longer published). Use **`oci://ghcr.io/llm-d/charts/llm-d-router-gateway`** (no `-dev` suffix) for both Step 3.7 and Step 3.12 installs — confirmed against `llm-d` repo's `guides/env.sh` (`ROUTER_GATEWAY_CHART`). Still only publishes the floating `v0` tag (this run pulled digest `sha256:c4a778aa…`). |
+| **`disagg-profile-handler` plugin params changed shape** | The old flat `parameters: {deciderPluginName: always-disagg-pd-decider}` (still used by most of the `llm-d` guides repo, not yet synced) now crash-loops the P/D EPP with `json: unknown field "deciderPluginName"`. Fixed in `manifests/optional/pd/pd-router.values.yaml` to the new nested format: `parameters: {profiles: {decode: decode, prefill: prefill}, deciders: {prefill: always-disagg-pd-decider}}`, matching `llm-d-router`'s own `deploy/config/sim-pd-epp-config.yaml`. A plain `helm upgrade` is not enough — the EPP pod has no config-checksum annotation, so `kubectl rollout restart deploy/llm-d-pd-epp -n llm-d` is required to pick up the fixed ConfigMap. |
+| Trace span names/shape | EPP span names dropped the `gateway.` prefix (`gateway.request` → `request`, `gateway.request_orchestration` → `request_orchestration`); the tokenizer hop renamed `HTTP POST` → `tokenize_render /v1/chat/completions/render`; per-scorer spans are now broken out under a `scoring` parent (`scorer.prefix-cache-scorer`, etc.) instead of one summary span. Precise-prefix trace grew **10 → 15 spans**; P/D trace grew **21 → 28 spans**. |
+| Monitoring stack | `kube-prometheus-stack` 88.1.3 (operator v0.93.0) → **88.5.4** (operator v0.93.1). |
+| HF model download | This run completed in **~39 s** (vs. ~22 min previously) — bandwidth/CDN variance, not a guaranteed steady-state; still pre-seed per Step 3.8. |
+| New doc | Added [`docs/request-lifecycle-zh.md`](docs/request-lifecycle-zh.md) — a beginner-oriented, component-by-component and CRD/CR-field-by-field walkthrough of one prompt's full lifecycle, built entirely from this run's live `kubectl get -o yaml` / Jaeger / Prometheus output. |
+
+> If you hit `CrashLoopBackOff` on an EPP after rebuilding from `upstream/main` with your own
+> `values.yaml`, check the logs for a JSON `unknown field` error first — it almost always means
+> a plugin's parameter schema moved ahead of the guide/values file you copied, not a YAML
+> indentation mistake. Cross-check against the plugin's own `deploy/config/*.yaml` in
+> `llm-d-router` for the current shape.

--- a/llm-d/llm-d-full-demo/docs/request-lifecycle-zh.md
+++ b/llm-d/llm-d-full-demo/docs/request-lifecycle-zh.md
@@ -1,0 +1,838 @@
+# llm-d 请求生命周期与 CRD/CR 详解（面向初学者）
+
+> 本文档基于 **2026-08-28** 在 `llm-d-full-demo`（Gateway API / agentgateway 模式）上的一次**全新重跑**编写：
+> Kind 集群从零创建，`llm-d-router`（EPP + routing-sidecar）与 `llm-d-inference-payload-processor`（IPP）三个镜像
+> 均从各自仓库的 **`upstream/main`** 重新 `git fetch` + `docker build`（不是复用旧镜像）。文中出现的所有
+> YAML、trace span、metric 数值，都是这次真实运行中 `kubectl get -o yaml` / Jaeger API / Prometheus API 抓取下来的
+> 原始输出，不是手写示例。
+>
+> 目标读者：第一次接触 llm-d 的人。读完后你应该能回答：“我发一个 prompt 进去，这个请求依次经过了哪些
+> 组件？每个组件在等哪个 CRD 的哪个字段？我怎么用 `kubectl` 看到它当前的状态？”
+>
+> 与主 [README.md](../README.md) 的关系：README 是**可执行的安装步骤**（第 3 节）和**串好的验证结果**
+> （第 4 节）；本文是**原理讲解**——同一套集群，但重点讲“为什么”和“CR 里每个字段是什么意思”。建议先看
+> README 把环境跑起来，再对照本文理解每一步。
+
+---
+
+## 目录
+
+1. [核心概念：5 分钟建立心智模型](#1-核心概念5-分钟建立心智模型)
+2. [整体架构图与组件表](#2-整体架构图与组件表)
+3. [涉及的所有 CRD/CR 速查手册](#3-涉及的所有-crdcr-速查手册)
+4. [一次请求的完整生命周期 —— 走 precise-prefix 路径](#4-一次请求的完整生命周期--走-precise-prefix-路径)
+5. [第二条路径：P/D（Prefill/Decode）分离](#5-第二条路径pd-prefilldecode-分离)
+6. [可观测性是怎么串起来的](#6-可观测性是怎么串起来的)
+7. [本次重跑踩到的 upstream 破坏性变更（附修复）](#7-本次重跑踩到的-upstream-破坏性变更附修复)
+8. [常见问题速查](#8-常见问题速查)
+
+---
+
+## 1. 核心概念：5 分钟建立心智模型
+
+在深入细节之前，先建立几个关键概念，后面所有内容都是围绕它们展开的：
+
+- **Gateway API 是"声明式"的**：你不是直接告诉 Envoy/agentgateway "把 `/v1/chat/completions` 转发到哪个
+  Pod"，而是创建一堆 CR（`Gateway`、`HTTPRoute`、`InferencePool`……），agentgateway 的**控制面**持续 watch
+  这些 CR，把它们编译成实际的转发规则（xDS 配置），推给**数据面**代理。这就是为什么你会看到大量
+  `status.conditions` —— 那是控制面在告诉你"我看到你的 CR 了，而且已经生效"。
+- **EPP（Endpoint Picker）不是 Kubernetes 自带的东西，是 llm-d 加的"大脑"**。标准的 Gateway API Inference
+  Extension 只定义了 `InferencePool` 这个"一组可路由的 Pod"的概念；真正"选哪个 Pod"这件事，是通过
+  `ext_proc`（gRPC 外部处理器）协议，把决策权交给一个叫 EPP 的进程。agentgateway 每收到一个请求，都会先
+  经过一次到 EPP 的 gRPC 往返，问它"这个请求该发去哪个 Pod"，EPP 回答后，agentgateway 才真正转发。
+- **CRD 定义"形状"，CR 是"一个实例"，`status` 字段是"实际状态"**。比如 `InferencePool`（CRD）定义了
+  "一组可路由的推理 Pod长什么样"；`llm-d`（CR，具体的一个 `InferencePool` 对象）就是"精确前缀缓存这个池
+  子"；它的 `status.parents[].conditions` 就是 agentgateway 告诉你"我已经把这个池子接进路由了"。
+- **一个请求 = 一条分布式 trace**。因为所有组件（agentgateway、IPP、EPP、routing-sidecar）都用 OpenTelemetry
+  导出 span 到同一个 `otel-collector` → `jaeger`，并且互相传递 W3C `traceparent`，所以你可以在 Jaeger 里
+  把"这一个 prompt 都经过了谁、每一步做了什么、花了多久"看得清清楚楚。**本文后面几乎所有的"输入/输出"都是
+  直接从真实 trace 的 span 属性里截出来的**。
+
+---
+
+## 2. 整体架构图与组件表
+
+本次验证的完整拓扑（精确前缀缓存池 + P/D 分离池，共用一个 Gateway）：
+
+```text
+                                          ┌─────── 默认路由(PathPrefix /) ───────▶ InferencePool "llm-d"
+                                          │              (EPP: precise-prefix)        │
+                                          │                                           ├──▶ vLLM 副本 1 ┐ KV 事件
+ 客户端 ─HTTP─▶ agentgateway ─ext_proc─▶ IPP ─▶(路由决策)                              └──▶ vLLM 副本 2 ┘ (ZMQ :5556)
+              (Gateway API 数据面,        (PreRouting 阶段)   │                                          │
+               trace 的根 span)                              └─ header x-llm-d-pool:pd ──▶ InferencePool "llm-d-pd"
+                                                                     (EPP: P/D 插件链)         │         │
+                                                                                               ▼         │
+                                                                    routing-sidecar ──prefill──▶ pd-prefill
+                                                                     (跑在 pd-decode 里)  ──decode───▶ pd-decode
+   trace ────────────────────────────── OTLP gRPC :4317 ─────▶ otel-collector ──▶ jaeger
+   metric ─────────────────── ServiceMonitor / PodMonitor ──▶ Prometheus ──────▶ Grafana ◀────────────────┘
+```
+
+| 组件 | 命名空间 | 作用 | 由哪个 CR 驱动 |
+| --- | --- | --- | --- |
+| `agentgateway`（控制面） | `agentgateway-system` | 实现 Gateway API + Gateway API Inference Extension 的控制器；watch `Gateway`/`HTTPRoute`/`InferencePool`/`AgentgatewayPolicy`，把它们编译成数据面配置并通过 xDS 下发 | `GatewayClass` |
+| `llm-d-inference-gateway`（数据面） | `llm-d` | 真正处理 HTTP 流量的代理进程；trace **根 span** 是 `POST /*`；把 W3C `traceparent` 注入到每一次 `ext_proc` 调用里 | `Gateway` |
+| `payload-processor`（IPP） | `llm-d` | llm-d 的 **Inference Payload Processor**，作为 `PreRouting` 阶段的 `ext_proc` 挂载。本次验证：本环境没有配置任何 payload 转换插件，它的实际作用是解析/校验请求体、设置 `Content-Length`，**并把上游 trace 上下文透传下去**（因此它是 Jaeger 里独立的一个 service） | `AgentgatewayPolicy`(`traffic.extProc`) |
+| `llm-d-epp` | `llm-d` | precise-prefix 池的 **Endpoint Picker**：打分、选 Pod，发出 `request` 等一系列 span，暴露 `llm_d_epp_*` 指标 | `InferencePool` "llm-d" |
+| `llm-d-pd-epp` | `llm-d` | **第二个** EPP，运行 P/D（disaggregation）插件链，发出 `pick_disagg_profile`/`prepare_disaggregation` 等 span | `InferencePool` "llm-d-pd" |
+| `precise-prefix-vllm`（×2） | `llm-d` | 真实 **vLLM CPU** 模型服务（`Qwen2.5-0.5B-Instruct`）；两副本是为了让"前缀打分器"真正有得选；通过 ZMQ `:5556` 发布 KV 事件 | 无专属 CRD，普通 `Deployment`，被 `InferencePool.spec.selector` 选中 |
+| `pd-prefill` / `pd-decode` | `llm-d` | P/D 池，跑在 `llm-d-inference-sim`（模拟器）上；`pd-decode` 里带了 **`llm-d-routing-sidecar`** 原生 sidecar，负责真正驱动 prefill→decode 的两段代理 | 同上 |
+| `otel-collector` + `jaeger` | `llm-d` | Trace 管道（OTLP gRPC → Jaeger） | 无 CRD，普通 Deployment |
+| `kube-prometheus-stack`（`llmd` release） | `llm-d-monitoring` | Prometheus + Grafana + Operator；发现并抓取 `ServiceMonitor`/`PodMonitor` | `ServiceMonitor`/`PodMonitor` |
+| `HTTPRoute` / `InferencePool` | `llm-d` | 一个 Gateway 上挂两条路由：chart 默认的 `/` → 池 `llm-d`；header 匹配的路由 → 池 `llm-d-pd` | 见第 3 节 |
+
+镜像来源（本次全部从 `upstream/main` 重新构建，arm64）：
+
+```console
+$ docker images | grep main
+ghcr.io/llm-d/llm-d-router-endpoint-picker-dev   main   ff7ff69bf604   commit ead3e86f (llm-d-router upstream/main)
+ghcr.io/llm-d/llm-d-routing-sidecar              main   f2c645d6af4b   commit ead3e86f (同上，同一仓库)
+ghcr.io/llm-d/llm-d-inference-payload-processor  main   a6a68d4ebbba   commit ff85c3d  (llm-d-inference-payload-processor upstream/main)
+```
+
+---
+
+## 3. 涉及的所有 CRD/CR 速查手册
+
+这一节是"字典"：每种 CRD 讲清楚——它是谁定义的、谁创建 CR、谁消费（watch）它、`spec` 里关键字段是什么
+意思、`status` 里的 condition 都代表什么。**所有示例 YAML 都是本次真实集群里 `kubectl get -o yaml` 的原始
+输出**（省略了 `resourceVersion`/`uid` 等噪音字段）。
+
+### 3.1 `GatewayClass`（`gateway.networking.k8s.io/v1`）
+
+- **谁创建**：`agentgateway` Helm chart 自己创建（不是你手工 apply 的）。
+- **谁消费**：你自己的 `Gateway` CR 通过 `spec.gatewayClassName` 引用它，告诉 Kubernetes "这个 Gateway 该
+  由谁来实现"。
+- **关键字段**：`spec.controllerName` = `agentgateway.dev/agentgateway`，是控制器用来"认领"匹配的
+  `Gateway`/`HTTPRoute` 的身份标识。
+
+```console
+$ kubectl get gatewayclass agentgateway
+NAME           CONTROLLER                      ACCEPTED   AGE
+agentgateway   agentgateway.dev/agentgateway   True       3s
+```
+
+`ACCEPTED=True` 就是控制器在说"我认领了这个 class，我会去实现所有指向它的 Gateway"。
+
+### 3.2 `Gateway`（`gateway.networking.k8s.io/v1`）—— 数据面的"入口"
+
+- **谁创建**：`kubectl apply -k $LLMD_REPO/guides/recipes/gateway/agentgateway -n llm-d`（README 3.5）。
+- **谁消费**：agentgateway 控制器 watch 到它后，会真正**起一个数据面 Pod**（也叫
+  `llm-d-inference-gateway`），并把 `spec.listeners` 编译成监听端口。
+- **关键字段**：
+  - `spec.gatewayClassName`：指回 3.1 的 GatewayClass。
+  - `spec.listeners[].port` / `.protocol`：本例是 `80/HTTP`。
+  - `spec.listeners[].allowedRoutes.namespaces.from: All`：允许任意命名空间的 `HTTPRoute` 挂载到这个监听器上。
+
+真实抓取（本次运行）：
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: llm-d-inference-gateway
+  namespace: llm-d
+spec:
+  gatewayClassName: agentgateway
+  listeners:
+  - allowedRoutes:
+      namespaces:
+        from: All
+    name: default
+    port: 80
+    protocol: HTTP
+status:
+  attachedListenerSets: 0
+  conditions:
+  - reason: Accepted
+    status: "True"
+    type: Accepted
+  - message: Successfully programmed Gateway
+    reason: Programmed
+    status: "True"
+    type: Programmed
+  listeners:
+  - attachedRoutes: 2          # 本次有 2 条 HTTPRoute 挂在这个监听器上（llm-d + llm-d-pd）
+    conditions:
+    - reason: Accepted
+      status: "True"
+      type: Accepted
+    - reason: NoConflicts
+      status: "False"          # False 是"没有冲突"的意思(Conflicted 这个 type 为 False 才是好事)
+      type: Conflicted
+    - reason: Programmed
+      status: "True"
+      type: Programmed
+    - reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+```
+
+**怎么读 `status.conditions`**：Gateway API 的 condition 遵循 Kubernetes 通用约定——`type` 是"检查项"，
+`status` 是这一项的真假。这里 4 个 condition 都是"好"状态：`Accepted`=True（语法/权限没问题）、
+`Programmed`=True（xDS 配置已经下发到数据面）、`ResolvedRefs`=True（所有它引用的对象，比如
+`InferencePool`，都能找到）、`Conflicted`=**False**（唯一一个"False 才是好事"的 condition，意思是"没有
+冲突"）。`attachedRoutes: 2` 直接告诉你有几条 `HTTPRoute` 真正挂上了这个监听器——如果你新建了一条
+`HTTPRoute` 但这个数字没涨，说明路由没匹配上（比如 `parentRefs` 写错了）。
+
+### 3.3 `HTTPRoute`（`gateway.networking.k8s.io/v1`）—— "匹配规则 → 转发到哪个池子"
+
+- **谁创建**：precise-prefix 那条由 `llm-d-router-gateway` chart 自动创建（`httpRoute.create=true`）；
+  P/D 那条是我们手工 `kubectl apply -f manifests/optional/pd/httproute-pd.yaml`。
+- **谁消费**：agentgateway 控制面把它编译进路由表；**匹配到某个请求后，`backendRefs` 决定转发到哪个
+  `InferencePool`**（注意：不是转发到某个具体 Pod，而是转发到一个"池子"，具体选哪个 Pod 是 EPP 的工作，
+  见 3.4）。
+
+precise-prefix 池的默认路由（真实抓取）：
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: llm-d
+  namespace: llm-d
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: llm-d-inference-gateway
+  rules:
+  - backendRefs:
+    - group: inference.networking.k8s.io
+      kind: InferencePool
+      name: llm-d
+      weight: 1
+    matches:
+    - path: {type: PathPrefix, value: /}
+    timeouts:
+      request: 300s
+status:
+  parents:
+  - conditions:
+    - reason: Accepted
+      status: "True"
+      type: Accepted
+    - reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+```
+
+P/D 池的 header 匹配路由（真实抓取，注意 `matches[].headers`）：
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: llm-d-pd
+  namespace: llm-d
+spec:
+  parentRefs:
+  - {group: gateway.networking.k8s.io, kind: Gateway, name: llm-d-inference-gateway}
+  rules:
+  - backendRefs:
+    - {group: inference.networking.k8s.io, kind: InferencePool, name: llm-d-pd, weight: 1}
+    matches:
+    - headers:
+      - {name: x-llm-d-pool, type: Exact, value: pd}
+      path: {type: PathPrefix, value: /}
+```
+
+两条路由都匹配 `PathPrefix: /`，但带 header 精确匹配的规则优先级更高（Gateway API 规范：更具体的匹配
+优先），所以**带 `x-llm-d-pool: pd` 请求头的请求走 P/D 池，其余所有请求走默认的 precise-prefix 池**。
+
+### 3.4 `InferencePool`（`inference.networking.k8s.io/v1`）—— "一组可路由的推理 Pod + 谁来决策"
+
+这是整个体系里**最核心**的 CRD，它把两件事绑在一起：① 用 label selector 圈出一组 Pod；② 指定由哪个
+Service 来做 `ext_proc` 决策（也就是 EPP）。
+
+- **谁创建**：`llm-d-router-gateway` Helm chart（每次 `helm install` 一个 release 就会创建一个
+  `InferencePool`，release 名就是池名）。
+- **谁消费**：`HTTPRoute.backendRefs` 引用它来决定转发目标；agentgateway 控制面 watch 它的
+  `spec.endpointPickerRef` 后，在数据面为**这个池子的所有流量**挂一个到 EPP 的 `ext_proc` 调用。
+
+真实抓取（precise-prefix 池）：
+
+```yaml
+apiVersion: inference.networking.k8s.io/v1
+kind: InferencePool
+metadata:
+  name: llm-d
+  namespace: llm-d
+spec:
+  appProtocol: http
+  endpointPickerRef:
+    failureMode: FailOpen        # ← 关键字段，见下方解释
+    kind: Service
+    name: llm-d-epp
+    port: {number: 9002}
+  selector:
+    matchLabels:
+      llm-d.ai/guide: precise-prefix-cache-routing
+  targetPorts:
+  - number: 8000
+status:
+  parents:
+  - conditions:
+    - reason: Accepted
+      status: "True"
+      message: InferencePool has been accepted by controller agentgateway.dev/agentgateway
+      type: Accepted
+    - reason: ResolvedRefs
+      status: "True"
+      message: All InferencePool references have been resolved
+      type: ResolvedRefs
+    controllerName: agentgateway.dev/agentgateway
+```
+
+字段逐个讲：
+
+- **`spec.selector.matchLabels`**：这个池子里包含哪些 Pod。本例是 `llm-d.ai/guide:
+  precise-prefix-cache-routing`——两个 `precise-prefix-vllm-*` Pod 都带这个 label（`kubectl get pod
+  --show-labels` 可以验证）。**加一个新副本只需要让新 Pod 带上同样的 label，`InferencePool` 会自动纳入**，
+  不需要改任何 CR。
+- **`spec.targetPorts`**：Pod 上真正服务模型请求的端口（vLLM 的 `:8000`）。
+- **`spec.endpointPickerRef`**：指向做决策的 EPP Service（`llm-d-epp:9002`，这是 gRPC `ext_proc` 端口）。
+  **`failureMode: FailOpen`** 是个很容易被忽略但很重要的字段——如果 EPP 挂了/超时，`FailOpen` 表示"放行，
+  让 agentgateway 自己随便选一个健康 Pod 转发"，代价是丢失 KV-cache 感知路由；对照第 7 节会看到 IPP 那边
+  故意配的是 `FailClosed`（默认值），一旦 IPP 挂了会导致**所有流量 500**——这是本次重跑真实踩过的坑。
+- **`status.parents[].conditions`**：`Accepted=True` 代表 agentgateway 已经把这个池子接进了路由表；
+  `ResolvedRefs=True` 代表 `endpointPickerRef` 指向的 Service（`llm-d-epp`）真实存在且能解析。**如果你的
+  vLLM 副本迟迟收不到流量，第一步永远是先看这两个 condition 是不是 True。**
+
+P/D 池（`llm-d-pd`）结构完全一样，只是 `selector.matchLabels: llm-d.ai/guide: pd-disaggregation`，
+`endpointPickerRef.name: llm-d-pd-epp`——**这就是为什么 P/D 需要"自己的一整套 router release"**：一个 EPP
+进程只能加载一份插件配置，precise-prefix 和 P/D 的调度逻辑完全不同（打分器 vs. disaggregation 决策器），
+所以只能用两个独立的 `helm install`（`llm-d` 和 `llm-d-pd`），对应两个 `InferencePool`。
+
+### 3.5 `InferenceObjective`（`llm-d.ai/v1alpha2`）—— 请求优先级
+
+- **谁创建**：本 demo 里手工 `kubectl apply -f manifests/02-inferenceobjective.yaml`（可选，chart 默认不
+  创建）。
+- **谁消费**：EPP 的公平性/排队逻辑，用来给不同优先级的请求分配调度权重。
+
+```yaml
+apiVersion: llm-d.ai/v1alpha2
+kind: InferenceObjective
+metadata:
+  name: llm-d-standard
+  namespace: llm-d
+spec:
+  poolRef:
+    group: inference.networking.k8s.io
+    kind: InferencePool
+    name: llm-d       # 指向 3.4 的 InferencePool，把这个"优先级策略"绑定到具体的池子
+  priority: 0          # 数值越大优先级越高；同一个 poolRef 下可以创建多个不同 priority 的 InferenceObjective
+```
+
+注意这个 CR **没有 `status` 字段**——它是纯配置型的 CR，不需要控制器回填状态，EPP 只是在调度时读取它。
+
+### 3.6 `AgentgatewayPolicy`（`agentgateway.dev/v1alpha1`）—— agentgateway 特有的"策略挂载点"
+
+这是 agentgateway（而不是标准 Gateway API）自己扩展的 CRD，用来做 Gateway API 规范没覆盖的事情：挂
+`ext_proc`、开 tracing 等。`spec.targetRefs` 决定这个策略作用在哪个对象上（本例都是整个 `Gateway`）。
+
+**用途 A：给 Gateway 开自己的 trace 导出**（否则没有上游 `traceparent` 的请求，agentgateway 自己不会起
+根 span）：
+
+```yaml
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: gateway-tracing
+  namespace: llm-d
+spec:
+  targetRefs:
+  - {group: gateway.networking.k8s.io, kind: Gateway, name: llm-d-inference-gateway}
+  frontend:
+    tracing:
+      backendRef: {kind: Service, name: otel-collector, port: 4317}
+      protocol: GRPC
+      randomSampling: "true"   # 100% 采样，demo 环境用；生产环境应调低
+status:
+  ancestors:
+  - ancestorRef: {group: gateway.networking.k8s.io, kind: Gateway, name: llm-d-inference-gateway}
+    conditions:
+    - {reason: Valid, status: "True", type: Accepted}
+    - {reason: Attached, status: "True", type: Attached, message: Attached to all targets}
+```
+
+**用途 B：把 IPP 挂成 `PreRouting` 阶段的 `ext_proc`**（这是 IPP 能进 trace、能在 EPP 之前拦截请求的唯一
+方式——IPP 自己的 Helm chart 只认 `provider.name: istio|gke|none`，没有 agentgateway 的模板，必须靠这个
+CR 手动接线）：
+
+```yaml
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: ipp-extproc
+  namespace: llm-d
+spec:
+  targetRefs:
+  - {group: gateway.networking.k8s.io, kind: Gateway, name: llm-d-inference-gateway}
+  traffic:
+    phase: PreRouting          # ← 在路由决策(HTTPRoute匹配)之前就拦截
+    extProc:
+      backendRef: {kind: Service, name: payload-processor, port: 9004}
+status:
+  ancestors:
+  - conditions:
+    - {reason: Valid, status: "True", type: Accepted}
+    - {reason: Attached, status: "True", type: Attached}
+```
+
+`status.ancestors[].conditions` 里的 `Attached=True` 是排障时最该看的字段：如果这里是 False 或者干脆没有
+`ancestors`，说明这个策略压根没生效，不管你怎么发请求都不会经过 IPP。
+
+### 3.7 `PodMonitor` / `ServiceMonitor`（`monitoring.coreos.com/v1`）—— 指标怎么被发现
+
+- **谁创建**：`ServiceMonitor`（叫 `llm-d-epp-monitor`）由 router chart 自动创建；`PodMonitor`（叫
+  `decode`）由 `kubectl apply -k .../modelserver/components/monitoring/` 创建，抓 vLLM 的 `/metrics`。
+- **谁消费**：Prometheus Operator watch 这些 CR，自动生成 Prometheus 的 scrape 配置——**你完全不需要手改
+  Prometheus 的配置文件**，这就是 Operator 模式的意义。
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: decode
+  namespace: llm-d
+  labels: {llm-d.ai/role: decode}
+spec:
+  podMetricsEndpoints:
+  - {interval: 30s, path: /metrics, port: modelserver}
+  selector:
+    matchLabels: {llm-d.ai/role: decode}
+```
+
+真实验证：
+
+```console
+$ curl -s "http://localhost:9091/api/v1/targets?state=active" | grep -o 'serviceMonitor/llm-d/llm-d-epp-monitor\|podMonitor/llm-d/decode'
+serviceMonitor/llm-d/llm-d-epp-monitor
+podMonitor/llm-d/decode
+```
+
+两个都出现说明 Prometheus 真的发现并且在抓这两类目标——这是 `PodMonitor`/`ServiceMonitor` 这类 CRD 唯一
+需要验证的事：**它有没有让 Prometheus 找到目标**，没有独立的业务语义。
+
+---
+
+## 4. 一次请求的完整生命周期 —— 走 precise-prefix 路径
+
+以下是这次真实发送的请求：
+
+```console
+$ GWIP=$(kubectl get svc llm-d-inference-gateway -n llm-d -o jsonpath='{.spec.clusterIP}')
+$ curl -X POST http://$GWIP:80/v1/chat/completions -H 'Content-Type: application/json' \
+  -d '{"model":"Qwen/Qwen2.5-0.5B-Instruct","messages":[{"role":"user","content":"..."}],"max_tokens":16}'
+```
+
+在把同一个长 prompt（>64 token，正好超过 vLLM 的 block size，才能真正命中一个 KV block）连续发送 6 次后，
+Jaeger 里抓到的完整 trace 长这样（**这是真实 trace 的原始 span 树，3 个 service，15 个 span**——比旧版本
+文档记录的 11 span 多，第 7 节会解释为什么）：
+
+```text
+[llm-d-inference-gateway] POST /*                                            ← trace 根 span
+  [payload-processor]      gateway.request
+    [llm-d-router/epp]     request
+      [llm-d-router/epp]     request_orchestration
+        [llm-d-router/epp]       tokenize_render /v1/chat/completions/render
+        [llm-d-router/epp]       produce_precise_prefix_cache
+          [llm-d-router/epp]         index_lookup
+        [llm-d-router/epp]       run_scheduler_profile
+          [llm-d-router/epp]         filter_endpoints
+          [llm-d-router/epp]         scoring
+            [llm-d-router/epp]           scorer.kv-cache-utilization-scorer
+            [llm-d-router/epp]           scorer.queue-scorer
+            [llm-d-router/epp]           scorer.prefix-cache-scorer
+          [llm-d-router/epp]         pick_endpoints
+        [llm-d-router/epp]       index_add
+```
+
+下面按时间顺序把每一跳拆开讲，**每一步都配真实抓到的 span 属性**。
+
+### Step 1 — 客户端 → agentgateway（数据面）
+
+- **组件**：`llm-d-inference-gateway` Pod（由 3.2 的 `Gateway` CR 驱动起来的数据面代理）。
+- **输入**：客户端的裸 HTTP POST（`Content-Type: application/json`，body 是 OpenAI 兼容的 chat completions
+  请求）。
+- **它做的事**：
+  1. 用 `Gateway.status.listeners[].attachedRoutes` 里编译好的路由表匹配请求路径/header，决定走哪条
+     `HTTPRoute`（本例：没带 `x-llm-d-pool` header → 走默认路由 → 目标是 `InferencePool: llm-d`）。
+  2. 开启这次请求的**根 span** `POST /*`（因为配置了 3.6 用途 A 的 `AgentgatewayPolicy`，`randomSampling:
+     "true"` 让它对没有上游 trace 的请求也主动起根），生成一个新的 W3C `traceparent`。
+  3. 按 3.6 用途 B 的 `AgentgatewayPolicy`（`phase: PreRouting`），先把请求（连同刚生成的 `traceparent`
+     header）通过 gRPC `ext_proc` 发给 IPP，**在真正做路由决策之前**。
+- **输出**：一次到 IPP 的 `ext_proc` gRPC 调用，带着请求头/体和 trace 上下文。
+
+### Step 2 — IPP（PreRouting 阶段的 ext_proc）
+
+- **组件**：`payload-processor` Pod。
+- **输入**：agentgateway 转发来的完整请求（headers + body），以及 header 里的 `traceparent`。
+- **它做的事**（源码 `pkg/handlers/server.go` / `request.go`，本次验证过 `main` 分支行为）：
+  1. `extractTraceContext()` 用 W3C propagator 从请求头里把 `traceparent` 解出来，**以它为父**开一个新
+     span `gateway.request`——这就是为什么 EPP 后面能成为 IPP 的子节点，而不是 agentgateway 的子节点。
+  2. 把 body 解析成 JSON（`HandleRequestBody`），运行配置好的 `preProcessors`/`profiles` 插件链——**本次
+     部署没有配置任何自定义插件**，所以这里实际上是"验证 body 合法 + 重算 `Content-Length`"，没有做真正
+     的字段改写。
+  3. 把（可能被修改过的）headers 通过 `HeaderMutation` 返回给 agentgateway；同时把 trace 上下文
+     `Inject` 回转发出去的 headers 里。
+- **输出**：`ClearRouteCache: true` + 一组 header mutation，交回给 agentgateway，agentgateway 据此重新
+  计算路由（然后才真正匹配到 `HTTPRoute`）。
+
+> **务实的说明**：README 的旧版本把 IPP 描述成"把 body 字段 `model` 改写成 `X-Gateway-Model-Name`
+> header"——那是 IPP 作为通用 payload 处理框架的**能力**，不是本次这套 `helm install ipp` 命令实际配置出
+> 来的行为（本次只开了 `tracing.enabled=true` 和 `secure-serving=false`，没挂任何转换插件）。本次验证到的
+> IPP 真实作用是：**校验请求体 + 在 trace 里占一跳 + 透传 trace 上下文**。想要它做 body/header 改写，需要
+> 在 `payloadProcessor.pluginsCustomConfig` 里显式配置处理器插件。
+
+### Step 3 — EPP（Endpoint Picker，precise-prefix 插件链）
+
+这是整条链路里逻辑最复杂的一跳，对应 3.4 里 `InferencePool.spec.endpointPickerRef` 指向的 Service。EPP 收
+到的也是一次 `ext_proc` gRPC 调用（这次是 agentgateway 因为 `HTTPRoute` 匹配到 `InferencePool: llm-d` 而
+自动发起的，不需要额外的 `AgentgatewayPolicy`——这一点和 IPP 不同，`InferencePool.spec.endpointPickerRef`
+本身就是"接线说明"）。EPP 内部按顺序做了这些事，每一步都是一个真实 span：
+
+**3a. `tokenize_render /v1/chat/completions/render`** —— EPP Pod 里的 `vllm-render` sidecar 用真实的
+Qwen tokenizer 把 messages 渲染 + 分词（这也是为什么 `2/2 Running` 的 EPP Pod 里有两个容器：`epp` +
+`vllm-render`）。**输入**：chat messages 数组；**输出**：token 数组，用来判断 prompt 落在哪些 KV block 里。
+
+**3b. `produce_precise_prefix_cache` → `index_lookup`** —— EPP 维护了一份**它自己内存里的 KV block 索引**
+（不是 vLLM 自己知道，是 EPP 通过订阅 vLLM 在 ZMQ `:5556` 发布的 KV 事件，自己建的一份镜像索引）。用上一步
+得到的 token 序列去查这份索引，看哪些 Pod 已经缓存了匹配的前缀 block。第 6 次重复请求时的真实属性：
+
+```text
+index_lookup                    llm_d.kv_cache.lookup.block_count = 1
+                                 llm_d.kv_cache.lookup.blocks_found = 1
+                                 llm_d.kv_cache.lookup.cache_hit = True      ← 真正命中了
+                                 llm_d.kv_cache.lookup.pod_filter_count = 2
+produce_precise_prefix_cache    llm_d.epp.producer.candidate_endpoints = 2
+                                 llm_d.epp.producer.max_match_blocks = 1
+                                 llm_d.epp.producer.total_blocks = 1
+```
+
+**输入**：token 序列；**输出**：`cache_hit=True` 这样的判定结果，会作为后面 `prefix-cache-scorer` 打分的
+依据，写进请求的 `CycleState`（跨插件共享的临时状态，不落 CR，只存在于这一次请求的内存里）。
+
+**3c. `run_scheduler_profile` → `filter_endpoints`** —— 从 `InferencePool.spec.selector` 圈出的所有 Pod
+里，先做一轮硬性过滤（比如排除不健康的 Pod），本例两个副本都健康，全部保留进入打分阶段。
+
+**3d. `scoring`（新增的子树，逐个打分器）** —— 这是本次重跑发现的**结构性变化**：现在每个打分器（scorer）
+都单独出一个 span，而不是像旧版本那样只留一个笼统的汇总 span。真实抓到的三个打分器（都是配置在
+`precise-prefix-router.values.yaml` 里的 `schedulingProfiles`）：
+
+```text
+scorer.kv-cache-utilization-scorer   weight=2   score.avg=1     score.max=1
+scorer.queue-scorer                  weight=2   score.avg=1     score.max=1
+scorer.prefix-cache-scorer           weight=3   score.avg=0.5   score.max=1
+```
+
+**输入**：`filter_endpoints` 过滤后剩下的候选 Pod 列表 + 上一步的 `cache_hit` 结果；**输出**：每个 Pod 在
+每个维度上的分数。`prefix-cache-scorer` 的权重最高（3.0），因为它是这条路径的核心卖点——命中前缀的 Pod 会
+拿到更高分。
+
+**3e. `pick_endpoints`** —— 把每个打分器的 `score × weight` 加总，选出总分最高的 Pod。真实结果：
+
+```text
+pick_endpoints    llm_d.epp.picker.top_endpoints = ["...-6zdgq-rank-0", "...-rvx8s-rank-0"]
+                  llm_d.epp.picker.top_scores    = [7, 4]
+```
+
+`7 = prefix-cache-scorer(命中时 1分 × 权重3) + kv-cache-utilization-scorer(1×2) + queue-scorer(1×2)`；没
+命中前缀的那个副本只拿 4 分（缺了 prefix 那 3 分）。**这就是"KV-cache 感知路由"在数字上的样子**——两个副本
+第一次都是冷的、打平分，从第二次开始命中过前缀的那个副本分数持续领先，后续同样内容的请求会一直粘在它
+身上。
+
+**3f. `index_add`** —— 请求转发出去之后，EPP 把这次请求新产生的 KV block 也加进自己的内存索引，供下一次
+请求复用。**输出**：无 API 返回值，纯粹是索引的副作用更新。
+
+**EPP 这一整段的输出**：一个 `ext_proc` 响应，告诉 agentgateway "把这次请求转发到
+`precise-prefix-vllm-...-6zdgq`"（`InferencePool.spec.targetPorts` 里定义的 `:8000`）。
+
+### Step 4 — agentgateway 转发到选中的 vLLM Pod
+
+agentgateway 拿到 EPP 的决策后，直接把（可能已被 IPP 修改过 header 的）原始请求代理到那个 Pod 的
+`:8000/v1/chat/completions`。**这一跳本身不产生新的 span**——vLLM CPU 镜像默认没有接自己的 OTel 导出器，
+所以 trace 到 `pick_endpoints` 这里事实上就结束了（trace 记录的是"决策过程"，不是"推理过程"）。vLLM 生成
+完成后把 completion 原路返回给 agentgateway，再原路返回给客户端。
+
+### Step 5（背景任务，不在这次请求的 trace 里）—— vLLM 发布 KV 事件
+
+vLLM 在处理请求的同时，通过 ZMQ `:5556` 把"我缓存了哪些 block"以事件的形式广播出去。EPP 有一个独立的
+后台订阅协程持续消费这些事件，更新 3b 提到的那份内存索引。**这个机制和 HTTP 请求路径是解耦的**——即使
+从来没有人发过第二个请求，只要 vLLM 在跑，这个事件流也一直在推。
+
+---
+
+## 5. 第二条路径：P/D（Prefill/Decode）分离
+
+给请求加一个 header 就会走完全不同的池子：
+
+```console
+$ curl -X POST http://$GWIP:80/v1/chat/completions -H 'Content-Type: application/json' \
+  -H 'x-llm-d-pool: pd' -d '{"model":"Qwen/Qwen2.5-0.5B-Instruct","messages":[...],"max_tokens":16}'
+```
+
+这次真实抓到的 trace 是 **4 个 service、28 个 span**（旧文档记录的是 21 span——本次多出的部分同样来自
+"打分器拆分成独立 span"这个结构性变化）：
+
+```text
+[llm-d-inference-gateway] POST /*
+  [payload-processor]        gateway.request
+    [llm-d-router/epp]         request
+      [llm-d-router/epp]         request_orchestration
+        [llm-d-router/epp]           pick_disagg_profile          # 第1次：决定要不要跑 decode
+        [llm-d-router/epp]           run_scheduler_profile        # decode 池内打分
+          [llm-d-router/epp]             filter_endpoints
+          [llm-d-router/epp]             scoring
+            [llm-d-router/epp]               scorer.active-request-scorer
+            [llm-d-router/epp]               scorer.prefix-cache-scorer
+          [llm-d-router/epp]             pick_endpoints
+        [llm-d-router/epp]           pick_disagg_profile          # 第2次：决定要不要跑 prefill
+        [llm-d-router/epp]           run_scheduler_profile        # prefill 池内打分
+          [llm-d-router/epp]             filter_endpoints
+          [llm-d-router/epp]             scoring
+            [llm-d-router/epp]               scorer.prefix-cache-scorer
+            [llm-d-router/epp]               scorer.queue-scorer
+            [llm-d-router/epp]               scorer.kv-cache-utilization-scorer
+          [llm-d-router/epp]             pick_endpoints
+        [llm-d-router/epp]           pick_disagg_profile          # 第3次：汇总，两段都选完了
+        [llm-d-router/epp]           prepare_disaggregation       # 组装 prefill 侧的转发信息
+        [llm-d-router/epp]           prepare_disaggregation       # 组装 decode 侧的转发信息
+    [llm-d-routing-sidecar]    POST /v1/chat/completions
+      [llm-d-routing-sidecar]      forward_request
+        [llm-d-routing-sidecar]        prefill
+          [llm-d-routing-sidecar]          HTTP POST               # → pd-prefill
+          [llm-d-routing-sidecar]          decode
+            [llm-d-routing-sidecar]            HTTP POST           # → pd-decode
+```
+
+### 5.1 为什么这次是"另一个 EPP"
+
+`x-llm-d-pool: pd` 这个 header 让 3.3 的 `HTTPRoute(llm-d-pd)` 匹配上，`backendRefs` 指向
+`InferencePool: llm-d-pd`，它的 `endpointPickerRef` 指向的是**另一个 Service**：`llm-d-pd-epp`（3.4 已
+讲过为什么必须是两个独立的 EPP release）。这个 EPP 加载的插件配置完全不同——本次真实生效的配置（修复过
+的版本，见第 7 节）：
+
+```yaml
+apiVersion: llm-d.ai/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: disagg-headers-handler
+- type: always-disagg-pd-decider     # 只要走到这个池子，就总是决定要做 P/D 分离
+- type: disagg-profile-handler
+  parameters:
+    profiles: {decode: decode, prefill: prefill}
+    deciders: {prefill: always-disagg-pd-decider}
+- type: prefill-filter
+- type: decode-filter
+- type: prefix-cache-scorer
+- type: queue-scorer
+- type: kv-cache-utilization-scorer
+- type: active-request-scorer
+schedulingProfiles:
+- name: prefill
+  plugins: [prefill-filter, {prefix-cache-scorer, weight: 3}, {queue-scorer, weight: 2}, {kv-cache-utilization-scorer, weight: 2}]
+- name: decode
+  plugins: [decode-filter, {active-request-scorer, weight: 2}, {prefix-cache-scorer, weight: 3}]
+```
+
+### 5.2 `disagg-profile-handler` 在做什么（对应 3 次 `pick_disagg_profile`）
+
+真实抓到的 3 次 `llm_d.epp.profile_handler.decision`：
+
+```text
+第1次: run_decode              → 先跑 "decode" scheduling profile，选出一个 decode Pod
+第2次: run_prefill              → 再跑 "prefill" scheduling profile，选出一个 prefill Pod
+第3次: complete_prefill-decode  → 两段都选完了，汇总决策
+```
+
+也就是说，`disagg-profile-handler` 本质是个**状态机**：先跑一遍 `decode` profile 里定义的
+`filter_endpoints`/`scoring`/`pick_endpoints`（选出 decode 侧 Pod），再跑一遍 `prefill` profile（选出
+prefill 侧 Pod），最后调用 `always-disagg-pd-decider` 插件确认"这次要不要真的做分离"（本例插件名字就叫
+"always"，所以永远是 True）。
+
+两次 `pick_endpoints` 的真实结果：
+
+```text
+decode 池打分:  candidate_endpoints=1  top_endpoints=["pd-decode-...-rank-0"]   top_scores=[2]
+prefill 池打分: candidate_endpoints=1  top_endpoints=["pd-prefill-...-rank-0"]  top_scores=[4]
+```
+
+（本例 P/D 池每种角色只有 1 个副本，所以"打分"退化成"确认存在"，分数本身意义不大——**这跟第 4 节
+precise-prefix 池 2 副本时分数才有区分度是同一个道理**。）
+
+### 5.3 `prepare_disaggregation`（两次）
+
+选完 Pod 后，EPP 需要把"prefill 该发去哪"这个信息编码进转发给 routing-sidecar 的请求里（因为真正发起
+prefill→decode 两段调用的不是 EPP 自己，是下一跳的 routing-sidecar）：
+
+```text
+prepare_disaggregation   llm_d.epp.pd.disaggregation_used = True
+                          llm_d.epp.pd.prefill_pod_address = 10.244.0.21
+                          llm_d.epp.pd.prefill_pod_port = 8000
+                          llm_d.epp.encode.disaggregation_used = False        ← 本例没有多模态，encode 分离用不到
+                          llm_d.epp.encode.reason = no_encode_profile_result
+```
+
+**EPP 这一段的输出**：转发目标定为 `pd-decode` Pod（因为 decode 侧承载了对外的 HTTP 入口），并且把
+`prefill_pod_address`/`prefill_pod_port` 塞进转发请求的 header 里，交给下一跳的 routing-sidecar。
+
+### 5.4 `llm-d-routing-sidecar` —— 真正执行两段代理的角色
+
+`pd-decode` Pod 是 `2/2 Running`——第二个容器就是 `llm-d-routing-sidecar`（Kubernetes 原生 sidecar，跟主
+容器 `llm-d-inference-sim` 共享网络命名空间）。它是 trace 里**第四个、也是唯一非 EPP 家族的 service**：
+
+```text
+forward_request   llm_d.pd_proxy.connector = nixlv2              # KV 传输连接器类型（本例被 sim 模拟）
+                   llm_d.pd_proxy.disaggregation_used = True
+                   llm_d.pd_proxy.prefill_target = 10.244.0.21:8000
+prefill            llm_d.pd_proxy.prefill.duration_ms = 1
+                    llm_d.pd_proxy.prefill_target = 10.244.0.21:8000
+decode              llm_d.pd_proxy.decode.target = localhost:8200   # decode 走本地环回，因为同 Pod
+                     llm_d.pd_proxy.true_ttft_ms = 1
+                     llm_d.pd_proxy.total_duration_ms = 1
+```
+
+**输入**：EPP 传下来的、带 `prefill_pod_address` 的请求；**它做的事**：先 `HTTP POST` 到
+`pd-prefill:8000` 发起 prefill（只算 prompt 的 KV，不生成 token），KV 结果通过 `nixlv2` connector "传输"
+给 decode 侧（本例是模拟器 `llm-d-inference-sim`，真实握手了协议但没有真的传输 KV 数据——第 4 节已经解释
+过 CPU vLLM 没有 `nixl` 模块，做不了真实的 P/D）；再 `HTTP POST` 到本地 `localhost:8200`（同 Pod 内的
+`llm-d-inference-sim` 主容器）发起 decode，拿到最终 completion 返回。**输出**：合并后的 OpenAI 格式
+响应，原路返回给客户端。
+
+---
+
+## 6. 可观测性是怎么串起来的
+
+### 6.1 一条 trace 是怎么"接力"传下去的
+
+核心是 [W3C Trace Context](https://www.w3.org/TR/trace-context/) 标准的 `traceparent` header，每一跳都
+做同一件事：**从收到的请求头里 `Extract` 出父 span，把自己的新 span 挂在它下面作为子节点，再 `Inject` 回
+转发出去的请求头里**。四个组件依次是：
+
+```
+agentgateway (起根 span，Inject traceparent)
+  → IPP (Extract 父=gateway根span, 起 gateway.request, Inject)
+    → EPP (Extract 父=IPP的span, 起 request, Inject)
+      → routing-sidecar (仅 P/D 路径; Extract 父=EPP的span, 起 forward_request)
+```
+
+**这也是为什么 IPP 挂载的 `phase` 很关键**：3.6 里 IPP 配的是 `PreRouting`（路由决策之前），所以 EPP 是
+IPP 的子节点，不是 agentgateway 的直接子节点——如果换成其他 phase，trace 树的形状会变。所有 span 最终都
+经同一个 OTLP gRPC 端点 `otel-collector:4317` 导出，`otel-collector` 转发给 `jaeger`，因为它们共享同一个
+`trace_id`，Jaeger 才能把跨 4 个进程的 span 拼成一棵树。
+
+### 6.2 指标是怎么被抓到的
+
+跟 trace 是完全独立的两条链路。EPP 和 vLLM 分别把 `/metrics`（Prometheus 文本格式）暴露在各自的端口上，
+3.7 讲过的 `ServiceMonitor`/`PodMonitor` 告诉 Prometheus Operator "去抓这些目标"，Operator 生成实际的
+scrape 配置。真实抓到的指标：
+
+```console
+$ curl -s ".../api/v1/query?query=llm_d_epp_request_total"
+llm-d-epp     job=llm-d-epp     value=7   # precise-prefix 路径本次发了 7 个请求（1+6）
+llm-d-pd-epp  job=llm-d-pd-epp  value=1   # P/D 路径发了 1 个请求
+```
+
+两个 EPP release 的指标带不同的 `job` label，这样 Grafana 里可以分开画（或者用 `sum by` 合并）。
+
+---
+
+## 7. 本次重跑踩到的 upstream breaking changes（附修复）
+
+这是本次**全新从 `upstream/main` 构建镜像**的重跑中，真实遇到、真实修复过的两个问题，供后来者对照：
+
+### 7.1 Router Helm chart 改名
+
+`llm-d-router` 仓库把 Gateway 模式的 chart 从 `llm-d-router-gateway-dev` 改成了 **`llm-d-router-gateway`**
+(去掉了 `-dev` 后缀，standalone 模式的 chart 同理从 `llm-d-router-standalone-dev` 变成
+`llm-d-router-standalone`)。README 里旧的 `oci://ghcr.io/llm-d/charts/llm-d-router-gateway-dev` 现在会
+`403 denied`（chart artifact 已经不存在，不是权限问题）：
+
+```console
+$ helm pull oci://ghcr.io/llm-d/charts/llm-d-router-gateway-dev --version v0
+Error: ... response status code 403: denied: requested access to the resource is denied
+$ helm pull oci://ghcr.io/llm-d/charts/llm-d-router-gateway --version v0     # 去掉 -dev 就好
+Pulled: ghcr.io/llm-d/charts/llm-d-router-gateway:v0
+```
+
+**验证方法**：`llm-d` 仓库自己的 `guides/env.sh` 是最权威的来源——它把默认值定义为
+`ROUTER_GATEWAY_CHART=oci://ghcr.io/llm-d/charts/llm-d-router-gateway`，跟仓库里几十个 `guides/*/README.md`
+的用法交叉印证过。
+
+### 7.2 `disagg-profile-handler` 插件参数格式改了
+
+旧格式（README 原文、`llm-d` 仓库 `guides/pd-disaggregation/` 等大量 guide **目前仍然**在用，尚未同步）：
+
+```yaml
+- type: disagg-profile-handler
+  parameters:
+    deciderPluginName: always-disagg-pd-decider
+```
+
+`llm-d-router` 的 `main` 分支已经把这个插件的参数结构改成了嵌套格式（`pkg/epp/framework/plugins/
+scheduling/profilehandler/disagg/disagg_profile_handler.go`），旧格式直接导致 EPP **`CrashLoopBackOff`**：
+
+```text
+"error":"failed to load the configuration - plugin instantiation failed: failed to build plugin
+dependency graph: failed to parse plugin parameters for disagg-profile-handler (type:
+disagg-profile-handler): failed to parse parameters of the disagg-profile-handler - json: unknown
+field \"deciderPluginName\""
+```
+
+新格式（本次验证过，见第 5.1 节完整配置）：
+
+```yaml
+- type: disagg-profile-handler
+  parameters:
+    profiles:
+      decode: decode        # 对应 schedulingProfiles 里 name=decode 的那个 profile
+      prefill: prefill       # 对应 schedulingProfiles 里 name=prefill 的那个 profile
+    deciders:
+      prefill: always-disagg-pd-decider   # 用哪个插件来决定"要不要做 P/D 分离"
+```
+
+对照来源是 `llm-d-router` 仓库自带的 `deploy/config/sim-pd-epp-config.yaml`（专门给 sim 模式配的样例，跟
+本 demo 场景一致）。已经把这个修复同步进了 `manifests/optional/pd/pd-router.values.yaml`。
+
+> **给读者的启示**：`llm-d-router-gateway-dev` chart 只发布一个浮动的 `v0` tag，**没有任何 pinned
+> release**（本次拉到的 digest 是 `sha256:c4a778aa...`）。这意味着"chart 版本"完全不能保证跟"你从
+> `upstream/main` 编译的 EPP 镜像"匹配——本次这两个坑就是 chart 里的默认 `values.yaml`（或者你手写的
+> `values.yaml`）落后于 `main` 分支代码导致的。**如果你也在跟着 `upstream/main` 走，EPP 一旦
+> `CrashLoopBackOff`，第一反应应该是 `kubectl logs` 看 "unknown field" 这类 JSON 解析错误，去对应仓库的
+> `deploy/config/*.yaml` 里找最新的参数格式，而不是怀疑自己的 YAML 缩进。**
+
+### 7.3 其它变化（非 breaking，但值得记录）
+
+- Grafana 的 llm-d Performance Dashboard 内部技术名从 `llm-d-performance-dashboard` 变成了
+  `llm-d-performance-kv-cache`，展示标题不变（还是"llm-d Performance Dashboard"）。
+- `kube-prometheus-stack` 从 88.1.3（operator v0.93.0）涨到了 **88.5.4**（operator v0.93.1）。
+- EPP 的 trace span 命名从 `gateway.request`/`gateway.request_orchestration` 简化成了 `request`/
+  `request_orchestration`（去掉了 `gateway.` 前缀——但 IPP 那一跳自己的 span 名仍然叫
+  `gateway.request`，两者不要搞混）；`HTTP POST`（token-producer 调 vllm-render）改名成了更语义化的
+  `tokenize_render /v1/chat/completions/render`；打分从一个笼统 span 拆成了 `scoring` + 每个
+  `scorer.<name>` 子 span（第 4、5 节已详细展开）。
+- HF 模型下载这次全程只花了 **39 秒**（不同上次记录的 ~22 分钟），可能是 CDN/带宽波动导致，不代表这个
+  耗时已经稳定变快，仍建议按 README 3.8 的做法预先在宿主机拉取模型缓存。
+
+---
+
+## 8. 常见问题速查
+
+| 现象 | 先看哪个 CR / 字段 | 本文对应章节 |
+| --- | --- | --- |
+| 发请求没反应/连不上 | `Gateway.status.conditions[Programmed]`、`.status.listeners[].attachedRoutes` | 3.2 |
+| 请求 500，日志里有 `ext_proc ... connection reset` | 对应的 `AgentgatewayPolicy.status.ancestors[].conditions[Attached]`；再查该 `ext_proc` backend 的 `secure-serving` 是否和 agentgateway 的明文/TLS 期望一致 | 3.6 |
+| 新副本一直不接流量 | `Pod` 的 label 是否匹配 `InferencePool.spec.selector.matchLabels`；`InferencePool.status.parents[].conditions[Accepted/ResolvedRefs]` | 3.4 |
+| 两个池子流量分不开 | `HTTPRoute` 的 `matches`（尤其 header 匹配）有没有被更宽泛的规则抢先匹配 | 3.3 |
+| 想看某次请求具体选中了谁、为什么 | Jaeger 里搜这次请求的 trace，看 `pick_endpoints` span 的 `llm_d.epp.picker.top_scores`/`top_endpoints` | 4 / 5 |
+| EPP `CrashLoopBackOff`，日志里有 `unknown field` | 你的 `pluginsCustomConfig` 参数格式落后于镜像里编译进去的 EPP 代码；去对应 commit 的 `deploy/config/*.yaml` 找最新格式 | 7.2 |
+| Prometheus 里查不到某个 `ServiceMonitor`/`PodMonitor` 抓到的指标 | 先确认 `.../api/v1/targets` 里这个目标是 `up`；如果 CR 刚创建就是空，八成是跟 Operator 重新生成配置撞了时间点，annotate 一下强制重新同步 | 3.7 |
+
+---
+
+*本文所有 YAML/日志/trace/metric 均为 2026-08-28 在本地 Kind 集群（`kindest/node:v1.35.0`）上真实运行
+`README.md` 第 3 节全部步骤后抓取，供教学参考；具体数值（Pod 名、IP、span 耗时）每次重跑都会变化，但
+CRD 的字段结构和组件间的调用关系是稳定的。*

--- a/llm-d/llm-d-full-demo/manifests/optional/pd/pd-router.values.yaml
+++ b/llm-d/llm-d-full-demo/manifests/optional/pd/pd-router.values.yaml
@@ -23,7 +23,11 @@ router:
         - type: always-disagg-pd-decider
         - type: disagg-profile-handler
           parameters:
-            deciderPluginName: always-disagg-pd-decider
+            profiles:
+              decode: decode
+              prefill: prefill
+            deciders:
+              prefill: always-disagg-pd-decider
         - type: prefill-filter
         - type: decode-filter
         - type: prefix-cache-scorer

--- a/llm-d/llm-d-gpu-kind/README-zh.md
+++ b/llm-d/llm-d-gpu-kind/README-zh.md
@@ -1,0 +1,672 @@
+# llm-d on Kind —— 把 Kind 直接跑在 GPU 主机上（不需要代理）
+
+这个 demo 回答的是 [`../llm-d-gpu-demo`](../llm-d-gpu-demo) 引出的一个后续问题：
+**"如果 Kind 本身就跑在 GPU 那台机器上，而不是跑在一台通过 socat 隧道桥接远程
+GPU 的笔记本上，会怎样？"**
+
+**答案：可以，而且能直接砍掉一整层。** 当 Kind 跑在 GPU 主机上时，vLLM 就变成
+了一个普普通通的 Kubernetes `Deployment`——由 kubelet 调度、健康检查、失败重
+启，像申请 `cpu`/`memory` 一样申请 `nvidia.com/gpu: 1`。不再需要 socat 桥接
+Pod，不再需要 SSH 到外部主机，也不再需要 ZMQ 隧道——EPP 订阅 KV-cache 事件时
+**直接连到 vLLM Pod 自己的 IP**，全程在集群内部。
+
+本文档是从零开始、逐条命令的搭建记录，所有输出都是 **2026-08-27** 在一台真实
+的 NVIDIA DGX Spark（GB10 Grace-Blackwell 芯片,aarch64 架构,CPU/GPU 统一内
+存架构）上跑出来的真实终端输出，不是事后补写的——包括中间踩的坑和崩溃现场，
+因为那部分往往最有参考价值。
+
+English version: [`README.md`](README.md).
+
+---
+
+## 1. 和 `llm-d-gpu-demo` 的区别
+
+| | `llm-d-gpu-demo` | `llm-d-gpu-kind`(本 demo) |
+|---|---|---|
+| Kind 跑在哪 | Mac(Docker Desktop) | **直接跑在 GPU 主机上**(Linux, DGX Spark) |
+| vLLM 跑在哪 | GPU 主机上用 `docker run` 起,**在 Kind 集群外面** | 一个普通的 K8s `Deployment`,**在 Kind 集群里面** |
+| EPP 怎么连到 vLLM | 经过一个 2 容器的 `socat` 代理 Pod,通过局域网隧道到外部主机 | 直接连,走 vLLM Pod 自己的集群内 IP |
+| GPU 作为 K8s 概念 | 不存在——调度器根本看不到 GPU | `nvidia.com/gpu` 是节点上一个真实的、可调度的资源 |
+| 故障恢复 | 手动(要 SSH 到远程主机 `docker restart`) | 自动(kubelet 按重启策略自动拉起) |
+| 额外的组件 | `gpu-vllm-proxy` Deployment + PodMonitor | 没有——就一个 Deployment |
+
+代价是:这套方案只在 **Kind 的控制面节点和 GPU 是同一台机器** 时才成立。如果你
+的 GPU 和跑 `kind create cluster` 的机器是分开的两台,那还是得退回
+`llm-d-gpu-demo` 里那种代理桥接的写法。
+
+## 2. 架构
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│ DGX Spark (192.168.1.112) — Ubuntu 24.04 aarch64, NVIDIA GB10        │
+│                                                                       │
+│  ┌───────────────────────────────────────────────────────────────┐  │
+│  │ Docker daemon (default-runtime = nvidia)                       │  │
+│  │                                                                 │  │
+│  │  ┌─────────────────────────────────────────────────────────┐  │  │
+│  │  │ Kind 节点容器 "llm-d-gpu-kind-control-plane"              │  │  │
+│  │  │ (/dev/nvidia*、驱动库都以 bind-mount 挂进来;               │  │  │
+│  │  │  容器里嵌套跑着自己的 containerd + kubelet)                 │  │  │
+│  │  │                                                            │  │  │
+│  │  │  containerd(注册了 RuntimeClass "nvidia")                  │  │  │
+│  │  │   │                                                        │  │  │
+│  │  │   ├─ Pod: agentgateway(数据面代理) :80                     │  │  │
+│  │  │   │      认识 Gateway API + InferencePool                  │  │  │
+│  │  │   │                                                        │  │  │
+│  │  │   ├─ Pod: llm-d-epp(2 个容器: epp + vllm-render)           │  │  │
+│  │  │   │      :9002 ext_proc gRPC, :9090 metrics                │  │  │
+│  │  │   │      直接订阅 vllm-qwen 那个 Pod IP 的 :5556 ZMQ        │  │  │
+│  │  │   │                                                        │  │  │
+│  │  │   ├─ Pod: vllm-qwen  (runtimeClassName: nvidia)             │  │  │
+│  │  │   │      resources.limits: {nvidia.com/gpu: 1}              │  │  │
+│  │  │   │      :8000 OpenAI HTTP API, :5556 ZMQ KV-cache 事件      │  │  │
+│  │  │   │      ── 真正在 GB10 GPU 上执行推理 ──                    │  │  │
+│  │  │   │                                                        │  │  │
+│  │  │   └─ DaemonSet: nvidia-device-plugin-daemonset (kube-system)│  │  │
+│  │  │          向 kubelet 注册 `nvidia.com/gpu` 这个资源           │  │  │
+│  │  └─────────────────────────────────────────────────────────┘  │  │
+│  └───────────────────────────────────────────────────────────────┘  │
+│                                                                       │
+│  (这台共享工作机上原本就在跑、与本 demo 无关的东西:                    │
+│   llm-d-gpu-demo 的 vllm-gpu-0 容器、ComfyUI、Grafana...)             │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+这里有两层容器嵌套,GPU 必须穿透这两层才能真正被 Pod 用到:
+
+1. **宿主机 Docker → Kind 节点容器。** Kind 的"节点"本质上"只是"一个 Docker
+   容器。要让它看到 GPU,得靠 Docker 的 `nvidia` runtime 把 `/dev/nvidia*`
+   和驱动库注入进去——机制跟 `docker run --gpus all` 完全一样。
+2. **containerd(节点容器内部)→ Pod 容器。** Kubernetes 的 Pod 根本不是由宿
+   主机的 Docker 起的,而是由节点容器**内部那个嵌套的 containerd** 起的。这
+   个嵌套 containerd 需要**它自己单独的一份** `nvidia-container-toolkit`,
+   并且自己单独注册 runtime——不做这一步,即使节点容器能看到 GPU,Kind 里
+   的 Pod 也永远看不到。
+
+漏掉任意一层,是这类搭建"悄无声息失败"最常见的原因(节点能看到 GPU,Pod 看
+不到,或者反过来)。
+
+## 3. 前置条件
+
+| 要求 | 为什么 | 怎么检查 |
+|---|---|---|
+| Linux 主机 + NVIDIA GPU + 驱动 | Kind 的"节点容器拿到 GPU"这套技巧在 Docker Desktop for Mac/Windows 上不存在——它们的 Linux 虚拟机压根没有 GPU 穿透能力 | `nvidia-smi` |
+| 主机上装了 `nvidia-container-toolkit` | 提供 `nvidia-ctk` 命令,以及 Docker/containerd 实际会调用的 `nvidia-container-runtime` | `dpkg -l \| grep nvidia-container-toolkit` |
+| 当前用户在 `docker` 组里 | 我们不用 `sudo` 装 kind/kubectl/helm,也不用 `sudo` 跑 `docker`/`kind`/`kubectl` | `docker ps`(不需要 `sudo`) |
+| 有 `sudo` 权限 | 有三条**一次性**的主机级配置命令是真的需要 root 权限:改 `/etc/docker/daemon.json`、改 `/etc/nvidia-container-runtime/config.toml`、`systemctl restart docker` | — |
+| 主机能访问外网 | 要拉 `kindest/node`、`nvcr.io/nvidia/vllm:26.05-py3`(约 9.5GB)、device-plugin 镜像,还要从 Hugging Face 下模型 | `curl -sS -o /dev/null -w '%{http_code}\n' https://github.com` |
+
+本次实际使用的环境:
+
+```console
+$ uname -a
+Linux spark 6.14.0-1015-nvidia #15-Ubuntu SMP PREEMPT_DYNAMIC Tue Nov 25 18:02:16 UTC 2025 aarch64 aarch64 aarch64 GNU/Linux
+$ docker version --format '{{.Server.Version}}'
+28.5.1
+$ nvidia-smi --query-gpu=name,driver_version --format=csv
+name, driver_version
+NVIDIA GB10, 580.126.09
+```
+
+> **后面会踩到的 GB10 特殊之处:** 这颗芯片是 CPU/GPU 统一内存架构,所以
+> `nvidia-smi --query-gpu=memory.total` 会显示 `[N/A]`,NVML 的
+> `nvmlDeviceGetMemoryInfo()` 调用会返回 `Not Supported`。这会让旧版本的
+> NVIDIA k8s device plugin 直接崩溃(见步骤 7)。
+
+## 4. 逐步搭建
+
+### 步骤 1 —— 装 kind、kubectl、helm(不用 sudo)
+
+直接装到 DGX Spark 上的 `~/bin`,因为没有 `sudo` 权限写 `/usr/local/bin`:
+
+```console
+$ curl -sSL -o ~/bin/kind https://kind.sigs.k8s.io/dl/v0.31.0/kind-linux-arm64 && chmod +x ~/bin/kind
+$ ~/bin/kind version
+kind v0.31.0 go1.25.5 linux/arm64
+
+$ curl -sSL -o ~/bin/kubectl "https://dl.k8s.io/release/$(curl -sSL https://dl.k8s.io/release/stable.txt)/bin/linux/arm64/kubectl" && chmod +x ~/bin/kubectl
+$ ~/bin/kubectl version --client
+Client Version: v1.37.0
+
+$ HELM_INSTALL_DIR=~/bin bash <(curl -sSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3) --no-sudo
+$ ~/bin/helm version
+version.BuildInfo{Version:"v3.21.4", ...}
+```
+
+### 步骤 2 —— 给 Docker 配置 GPU 穿透
+
+**这一步真的需要 root**,所以没法直接通过非交互式的 SSH 管道自动跑(`sudo`
+要弹密码提示需要一个真实的 tty)。要用 `ssh -t` 强制分配终端来跑:
+
+```console
+$ sudo nvidia-ctk runtime configure --runtime=docker --set-as-default
+$ sudo sed -i 's/#accept-nvidia-visible-devices-as-volume-mounts = false/accept-nvidia-visible-devices-as-volume-mounts = true/' /etc/nvidia-container-runtime/config.toml
+$ sudo systemctl restart docker
+```
+
+每一行做了什么:
+
+- `nvidia-ctk runtime configure --runtime=docker --set-as-default` 会写
+  `/etc/docker/daemon.json`,让 Docker 知道有个叫 `nvidia` 的 runtime,**并
+  且把它设成这台主机上所有新容器的默认 runtime**:
+  ```json
+  {
+      "default-runtime": "nvidia",
+      "runtimes": { "nvidia": { "path": "nvidia-container-runtime", "args": [] } }
+  }
+  ```
+  `nvidia-container-runtime` 只是 `runc` 外面薄薄一层包装:对于没有申请 GPU
+  的容器,它的行为和纯 `runc` 完全一样,只有在被明确要求时才会注入 GPU 设备
+  和驱动库。
+- `sed` 那一行打开了 `accept-nvidia-visible-devices-as-volume-mounts`。这是
+  下一步能成立的关键机关:**Kind 根本没有 `--gpus` 这个参数**,所以没有常规
+  办法告诉 runtime"这个容器要用 GPU"。打开这个开关后,runtime 会把"目标路
+  径匹配 `/var/run/nvidia-container-devices/<name>` 的一个 bind-mount",等
+  效地当成设置了环境变量 `NVIDIA_VISIBLE_DEVICES=<name>`——而 Kind 的集群
+  配置格式**恰好**支持加任意 bind mount(`extraMounts`)。
+- `systemctl restart docker` 让新的默认 runtime 生效。
+
+> ### ⚠️ 真实踩坑:这次重启干掉了一个无关的正在运行的容器
+>
+> 这台 DGX Spark 上本来就有个叫 `vllm-gpu-0` 的容器在跑(`llm-d-gpu-demo`
+> 用的那个真实 GPU 后端)。`systemctl restart docker` 并不是"加个配置、容
+> 器照常跑着"——Docker 的默认行为(没开 `--live-restore`)是在 daemon 干净
+> 关闭时**停掉所有正在运行的容器**,而用纯 `docker run -d`(没加 `--restart`
+> 策略)启动的容器,**不会自己重新拉起来**:
+> ```console
+> $ docker ps -a
+> CONTAINER ID   IMAGE                           STATUS                      NAMES
+> 5e4f32eba04a   nvcr.io/nvidia/vllm:26.05-py3   Exited (0) 22 seconds ago   vllm-gpu-0
+> ```
+> 修复方法:`docker start vllm-gpu-0`——但它原来的 `--gpu-memory-utilization
+> 0.03` 这次没能成功分配 KV-cache 显存(见下一条踩坑),所以最后还是得用稍
+> 大一点的比例重新建了这个容器。**教训:在一台还跑着其他"裸" GPU 容器的主
+> 机上执行 `systemctl restart docker` 并不安全——要么提前给那些容器加上
+> `--restart=unless-stopped`,要么就做好手动重启它们的准备。**
+
+### 步骤 3 —— 用 GPU bind-mount 这个机关创建 Kind 集群
+
+`kind/kind-config.yaml`:
+
+```yaml
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: llm-d-gpu-kind
+nodes:
+- role: control-plane
+  extraMounts:
+  - hostPath: /dev/null
+    containerPath: /var/run/nvidia-container-devices/all
+  kubeadmConfigPatches:
+  - |
+    kind: KubeletConfiguration
+    maxPods: 250
+    evictionHard:
+      memory.available: "512Mi"
+```
+
+`hostPath: /dev/null` 只是随便找一个保证一定存在的文件,runtime 那个钩子读
+的是**目标路径**,源路径内容根本不重要。挂载点的 basename 是 `all`,意思是
+"把这台主机上所有 GPU 都暴露出来"。
+
+```console
+$ kind create cluster --config kind/kind-config.yaml
+Creating cluster "llm-d-gpu-kind" ...
+ ✓ Ensuring node image (kindest/node:v1.35.0) 🖼
+ ✓ Preparing nodes 📦
+ ✓ Writing configuration 📜
+ ✓ Starting control-plane 🕹️
+ ✓ Installing CNI 🔌
+ ✓ Installing StorageClass 💾
+Set kubectl context to "kind-llm-d-gpu-kind"
+```
+
+验证 GPU 真的穿透进了节点容器——**注意这时候是 Docker 看到了 GPU,Kubernetes
+还完全不知道**:
+
+```console
+$ docker exec llm-d-gpu-kind-control-plane ls -la /dev/ | grep -i nvidia
+crw-rw-rw-  1 root root  195, 254 nvidia-modeset
+crw-rw-rw-  1 root root  499,   0 nvidia-uvm
+crw-rw-rw-  1 root root  499,   1 nvidia-uvm-tools
+crw-rw-rw-  1 root root  195,   0 nvidia0
+crw-rw-rw-  1 root root  195, 255 nvidiactl
+
+$ docker exec llm-d-gpu-kind-control-plane nvidia-smi
+Thu Aug 27 11:23:06 2026
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 580.126.09    Driver Version: 580.126.09    CUDA Version: 13.0                |
+|   0  NVIDIA GB10   On  | 0000000F:01:00.0 Off |  N/A   50C  12W  0%  Default             |
++-----------------------------------------------------------------------------------------+
+```
+
+这一步成功的话,`nvidia-ctk` 也会顺带把匹配的驱动库(`libcuda.so`、
+`libnvidia-ml.so` 等)和设备节点一起挂进去,不需要额外操作。
+
+### 步骤 4 —— 让"嵌套的" containerd 也支持 GPU
+
+节点容器本身能看到 GPU 了,但 Kubernetes 的 Pod 是由节点容器**内部**那个
+containerd 起的——而它就是一个原封不动的 `kindest/node` 镜像,压根没装任何
+NVIDIA 相关工具。用节点自己的(可用的)外网,在里面装一遍:
+
+```console
+$ docker exec llm-d-gpu-kind-control-plane bash -c '
+  apt-get install -y -qq curl gnupg
+  curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+  curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
+    sed "s#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g" | \
+    tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+  apt-get update -qq
+  apt-get install -y -qq nvidia-container-toolkit
+'
+```
+
+然后在**嵌套的** containerd 里注册一个 `nvidia` runtime handler(故意**不**
+设为默认——只有明确声明 `runtimeClassName: nvidia` 的 Pod 才应该拿到 GPU 注
+入):
+
+```console
+$ docker exec llm-d-gpu-kind-control-plane nvidia-ctk runtime configure --runtime=containerd --config=/etc/containerd/config.toml
+INFO[...] Wrote updated config to /etc/containerd/conf.d/99-nvidia.toml
+INFO[...] It is recommended that containerd daemon be restarted.
+```
+
+> containerd 2.x 支持在 `/etc/containerd/conf.d/` 下放"drop-in"配置文件
+> (主配置里的 `imports = ["/etc/containerd/conf.d/*.toml"]` 会自动导入它
+> 们)——`nvidia-ctk` 选择写到这里,而不是直接改 `config.toml`。两种方式效
+> 果一样,drop-in 这种写法反而更干净。
+
+```console
+$ docker exec llm-d-gpu-kind-control-plane systemctl restart containerd
+$ docker exec llm-d-gpu-kind-control-plane systemctl is-active containerd
+active
+$ kubectl get nodes
+NAME                           STATUS   ROLES           AGE   VERSION
+llm-d-gpu-kind-control-plane   Ready    control-plane   20s   v1.35.0
+```
+
+节点在 containerd 重启前后一直保持 `Ready`——kubelet 自己重新连上了。
+
+现在用一个 `RuntimeClass` 告诉 Kubernetes 这个 runtime 的存在:
+
+```console
+$ kubectl apply -f - <<'YAML'
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: nvidia
+handler: nvidia
+YAML
+runtimeclass.node.k8s.io/nvidia created
+```
+
+### 步骤 5 —— 部署 NVIDIA device plugin(顺带踩到 GB10 的 bug)
+
+device plugin 的作用是把"containerd 能在这块 GPU 上起 Pod"变成"调度器认识
+`nvidia.com/gpu` 这个资源"。第一次尝试,用了一个相对新但不是最新的镜像 tag:
+
+```console
+$ kubectl apply -f manifests/nvidia-device-plugin.yaml   # 这时候用的是 v0.17.1
+$ kubectl -n kube-system logs -l name=nvidia-device-plugin-ds --tail 5
+E... error visiting device: error building Device: error getting device memory: Not Supported
+```
+
+正是 §3 提到的 GB10 统一内存的坑:插件调用 `nvmlDeviceGetMemoryInfo()` 来
+构建内部的设备映射表,GB10 因为没有独立显存可报告而返回 `Not Supported`,
+v0.17.1 把这个当成致命错误处理。这是一个
+[已知且已修复的问题](https://github.com/NVIDIA/k8s-device-plugin/issues/1482)——
+**v0.17.4 及以后的版本会容忍这个 `Not Supported` 响应。** 把镜像 tag 升级:
+
+```console
+$ kubectl apply -f manifests/nvidia-device-plugin.yaml   # 现在是 v0.17.4
+$ kubectl -n kube-system logs -l name=nvidia-device-plugin-ds --tail 5
+W... devices.go:77] Ignoring error getting device memory: Not Supported
+I... server.go:195] Starting GRPC server for 'nvidia.com/gpu'
+I... server.go:146] Registered device plugin for 'nvidia.com/gpu' with Kubelet
+```
+
+验证节点现在真的对外声明了一个 GPU 资源:
+
+```console
+$ kubectl get node llm-d-gpu-kind-control-plane -o jsonpath='{.status.allocatable}' | tr ',' '\n' | grep gpu
+"nvidia.com/gpu":"1"
+```
+
+用一个最简单的冒烟测试 Pod 端到端验证一遍——还完全没涉及 llm-d,只是验证
+"一个申请了 `nvidia.com/gpu: 1` 的 Pod,是不是真的能在真实 GPU 上跑
+`nvidia-smi`":
+
+```console
+$ kubectl apply -f - <<'YAML'
+apiVersion: v1
+kind: Pod
+metadata:
+  name: gpu-smoke-test
+spec:
+  restartPolicy: Never
+  runtimeClassName: nvidia
+  containers:
+  - name: cuda
+    image: nvcr.io/nvidia/cuda:13.0.1-base-ubuntu24.04
+    command: ["nvidia-smi"]
+    resources:
+      limits: { nvidia.com/gpu: 1 }
+YAML
+$ kubectl logs gpu-smoke-test
+Thu Aug 27 11:27:56 2026
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 580.126.09    Driver Version: 580.126.09    CUDA Version: 13.0                |
+|   0  NVIDIA GB10   On  | 0000000F:01:00.0 Off |  N/A   50C  12W  0%  Default             |
++-----------------------------------------------------------------------------------------+
+```
+
+**这是整个 demo 的核心里程碑**:一个普通的 `kubectl apply` 出来的 Pod,因为
+申请了 `nvidia.com/gpu: 1` 而被默认调度器排上了这块真实的 GPU,在上面跑了真
+代码。不需要代理,不需要外部主机,也不需要手动 `docker run`。
+
+### 步骤 6 —— 命名空间、CRD、agentgateway、Gateway
+
+```console
+$ kubectl apply -f - <<'YAML'
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: llm-d
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa
+  namespace: llm-d
+automountServiceAccountToken: false
+YAML
+
+$ kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/standard-install.yaml
+$ kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/v1.5.0/v1-manifests.yaml
+$ kubectl apply -k "https://github.com/llm-d/llm-d-router/config/crd?ref=main"
+```
+
+这三条命令依次安装的是:**Gateway API**(`GatewayClass`、`Gateway`、
+`HTTPRoute`——Kubernetes 的"下一代 Ingress");**Gateway API Inference
+Extension / GAIE**(`InferencePool`——专门表示"一组模型服务副本"的资源类
+型,是 EPP 要监听的对象);**llm-d 自己的 CRD**(`InferenceObjective`、
+`InferenceModelRewrite`)。
+
+```console
+$ helm upgrade --install agentgateway-crds oci://cr.agentgateway.dev/charts/agentgateway-crds \
+  --namespace agentgateway-system --create-namespace --version v1.1.0
+
+$ helm upgrade --install agentgateway oci://cr.agentgateway.dev/charts/agentgateway \
+  --namespace agentgateway-system --create-namespace --version v1.1.0 \
+  --set inferenceExtension.enabled=true
+
+$ kubectl apply -k "https://github.com/llm-d/llm-d/guides/recipes/gateway/agentgateway?ref=main" -n llm-d
+gateway.gateway.networking.k8s.io/llm-d-inference-gateway created
+
+$ kubectl get gatewayclass agentgateway
+NAME           CONTROLLER                      ACCEPTED   AGE
+agentgateway   agentgateway.dev/agentgateway   True       2s
+
+$ kubectl get gateway -n llm-d
+NAME                      CLASS          ADDRESS   PROGRAMMED   AGE
+llm-d-inference-gateway   agentgateway             True         6s
+```
+
+`--set inferenceExtension.enabled=true` 是那个开关——打开后 agentgateway 才
+会原生监听 `InferencePool` 资源,并知道怎么去调用一个 EPP 的 `ext_proc` 接
+口;不打开的话就得自己手写一条 `AgentgatewayPolicy` 来接线。
+
+### 步骤 7 —— 把 vLLM 部署成原生的 GPU Deployment
+
+这一步完全替代了 `llm-d-gpu-demo` 里那整个 `gpu-vllm-proxy` Deployment。完
+整清单见 [`manifests/vllm-gpu-native.yaml`](manifests/vllm-gpu-native.yaml),
+关键部分:
+
+```yaml
+spec:
+  template:
+    metadata:
+      labels:
+        llm-d.ai/role: decode
+        llm-d.ai/guide: gpu-kind-native   # <- EPP 的 selector 靠这个匹配
+        llm-d.ai/model: Qwen2.5-1.5B-Instruct
+    spec:
+      serviceAccountName: sa
+      runtimeClassName: nvidia            # <- 声明要用 GPU 注入
+      containers:
+        - name: vllm
+          image: nvcr.io/nvidia/vllm:26.05-py3
+          command: ["vllm", "serve", "Qwen/Qwen2.5-1.5B-Instruct"]
+          args:
+            - "--port=8000"
+            - "--block-size=64"
+            - "--gpu-memory-utilization=0.05"
+            - "--max-model-len=4096"
+            - "--enforce-eager"
+            - "--kv-events-config={...,\"endpoint\":\"tcp://*:5556\",...}"
+          resources:
+            limits: { nvidia.com/gpu: 1 }   # <- 这就是全部的关机
+```
+
+```console
+$ kubectl apply -f manifests/vllm-gpu-native.yaml
+deployment.apps/vllm-qwen created
+$ kubectl -n llm-d get pods -l llm-d.ai/guide=gpu-kind-native
+NAME                        READY   STATUS              RESTARTS   AGE
+vllm-qwen-66c85c6f4-hfbgd   0/1     ContainerCreating   0          0s
+```
+
+> ### ⚠️ 真实踩坑 1:冷拉镜像要花好几分钟
+>
+> Kind 嵌套的 containerd 有**自己独立的镜像存储**,和宿主机 Docker 的镜像缓
+> 存完全是两码事——即便 `vllm-gpu-0` 在 Kind 之外已经拉过这个镜像,集群内
+> 的这个 Pod 还是得把全部 9.5GB 重新拉一遍:
+> ```console
+> Normal  Pulling  kubelet  spec.containers{vllm}: Pulling image "nvcr.io/nvidia/vllm:26.05-py3"
+> Normal  Pulled   kubelet  Successfully pulled image ... in 2m58.136s. Image size: 9486739495 bytes.
+> ```
+>
+> ### ⚠️ 真实踩坑 2:Pod 崩了一次,然后自己好了
+> ```console
+> $ kubectl -n llm-d get pods -l llm-d.ai/guide=gpu-kind-native
+> NAME                        READY   STATUS    RESTARTS      AGE
+> vllm-qwen-66c85c6f4-hfbgd   0/1     Running   1 (42s ago)   4m
+> ```
+> 第一次尝试踩到了和上面 `vllm-gpu-0` 那次一样的 KV-cache 显存分配错误
+> (`ValueError: No available memory for the cache blocks`)——不意外,因为
+> 这块 GPU 此刻同时被第二个 vLLM 引擎和宿主机上的 ComfyUI 会话共享着。**这
+> 次没有人手动 `docker start`——kubelet 按默认重启策略自己把容器拉起来
+> 了,第二次直接就成功了。** 这正是本 demo 起源的那个概念性讨论
+> ("Kubernetes 管理容器的生命周期")在实际操作层面的具体体现。
+
+```console
+$ kubectl -n llm-d wait --for=condition=Ready pod -l llm-d.ai/guide=gpu-kind-native --timeout=900s
+pod/vllm-qwen-66c85c6f4-hfbgd condition met
+$ kubectl -n llm-d get pods -l llm-d.ai/guide=gpu-kind-native
+NAME                        READY   STATUS    RESTARTS      AGE
+vllm-qwen-66c85c6f4-hfbgd   1/1     Running   1 (93s ago)   4m51s
+```
+
+### 步骤 8 —— 安装路由层(EPP + InferencePool)
+
+```console
+$ kubectl create secret generic llm-d-hf-token -n llm-d \
+  --from-literal=HF_TOKEN="" --dry-run=client -o yaml | kubectl apply -f -
+
+$ helm install llm-d oci://ghcr.io/llm-d/charts/llm-d-router-gateway --version v0 \
+  -f helm-values/precise-prefix-router.values.yaml \
+  -f helm-values/gw-kind-gpu.values.yaml \
+  --set provider.name=none \
+  --set httpRoute.create=true \
+  --set httpRoute.inferenceGatewayName=llm-d-inference-gateway \
+  -n llm-d
+NAME: llm-d
+STATUS: deployed
+```
+
+`helm-values/gw-kind-gpu.values.yaml` 里设置了
+`router.modelServers.matchLabels: {llm-d.ai/guide: gpu-kind-native}`——就这
+一行,是 EPP 和真实 vLLM Pod 之间**全部**的连接点;其余所有路由逻辑(打分、
+KV-cache 感知)都是通用的,根本不知道也不关心这次的后端恰好是块真实 GPU。
+
+```console
+$ kubectl -n llm-d get pods
+NAME                                       READY   STATUS    RESTARTS      AGE
+llm-d-epp-7c8c9f5b8d-tf7sm                 2/2     Running   0             5m17s
+llm-d-inference-gateway-86b846c879-4dcjb   1/1     Running   0             6m20s
+vllm-qwen-66c85c6f4-hfbgd                  1/1     Running   1 (2m ago)    5m57s
+```
+
+**整个 demo 里最重要的一行日志**——证明代理这一层是真的彻底消失了:
+
+```console
+$ kubectl -n llm-d logs deploy/llm-d-epp -c epp | grep zmq
+{"logger":"zmq-subscriber","msg":"Connected subscriber socket","endpoint":"tcp://10.244.0.10:5556"}
+```
+
+`10.244.0.10` 就是 `vllm-qwen` 这个 Pod 自己的 IP。对比 `llm-d-gpu-demo`
+里,同样这行日志指向的是 `gpu-vllm-proxy` 那个 Pod 的 IP,再由它转发到局域
+网里完全另一台机器上。
+
+### 步骤 9 —— 通过 Gateway 做端到端测试
+
+```console
+$ GWIP=$(kubectl get svc llm-d-inference-gateway -n llm-d -o jsonpath='{.spec.clusterIP}')
+$ kubectl run trig --rm -i --restart=Never --image=curlimages/curl:8.7.1 -n llm-d -- \
+  curl -sS -X POST http://$GWIP:80/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"Qwen/Qwen2.5-1.5B-Instruct","messages":[{"role":"user","content":"Say hi in exactly three words."}],"max_tokens":20}'
+
+{"id":"chatcmpl-e343c7b9-7fc3-428c-a36f-7145163e22b7","object":"chat.completion",
+ "model":"Qwen/Qwen2.5-1.5B-Instruct",
+ "choices":[{"index":0,"message":{"role":"assistant","content":"Hello there!"},"finish_reason":"stop"}],
+ "usage":{"prompt_tokens":36,"completion_tokens":4,"total_tokens":40}}
+```
+
+一个真正的补全结果,来自真实 GPU,走完了完整的 Gateway → EPP →
+InferencePool → Pod 这条链路,而这个集群里唯一"非标准"的地方,只有一个
+Deployment 上的 `runtimeClassName: nvidia`。
+
+对应的 EPP 端日志——同一个请求,`x-request-id` 和上面 `chatcmpl-...` 的 id
+对得上:
+
+```console
+$ kubectl -n llm-d logs deploy/llm-d-epp -c epp --tail 30 | grep prefix
+{"logger":"prefix","msg":"PrefixCacheMatchInfo not found for endpoints, assigning score 0",
+ "x-request-id":"e343c7b9-7fc3-428c-a36f-7145163e22b7","incomingModelName":"Qwen/Qwen2.5-1.5B-Instruct"}
+```
+
+(打分是 0,因为这是第一个请求——KV-cache 索引里还什么都没有。如果第二个请
+求的 prompt 前缀和第一个有重叠,打分就会大于 0;不过本 demo 里只有一个后端
+Pod,打分再高也改变不了"选哪个 Pod"这个结果——但一旦扩到 N 个副本,驱动真
+实路由决策的就是这同一套机制。)
+
+确认此刻这块 GPU 上同时活着两个 vLLM 引擎(本 demo 的 `vllm-qwen` + 旧
+`llm-d-gpu-demo` 的 `vllm-gpu-0`,后者完全没被打扰,一直在跑):
+
+```console
+$ nvidia-smi --query-compute-apps=pid,process_name,used_memory --format=csv
+pid, process_name, used_gpu_memory [MiB]
+3858903, VLLM::EngineCore, 6265 MiB
+3880364, VLLM::EngineCore, 5530 MiB
+```
+
+节点的资源记账现在把 GPU 当成和其他资源完全一样的东西来对待:
+
+```console
+$ kubectl describe node llm-d-gpu-kind-control-plane | sed -n '/Allocated resources/,/Events/p'
+Allocated resources:
+  Resource           Requests     Limits
+  --------           --------     ------
+  cpu                2950m (14%)  4100m (20%)
+  memory             8994Mi (7%)  6534Mi (5%)
+  nvidia.com/gpu     1            1
+```
+
+---
+
+## 5. 每个组件/CR 到底是什么
+
+| 资源 | 类型 | 命名空间 | 在这里的含义 |
+|---|---|---|---|
+| `RuntimeClass/nvidia` | K8s 内置类型 | 集群级 | 指向一个 containerd runtime handler 的命名指针。任何 Pod 只要设置 `spec.runtimeClassName: nvidia`,它的容器就会用 `nvidia-container-runtime`(而不是普通的 `runc`)来创建——真正把 `/dev/nvidia*` 和驱动库注入到这个容器里的正是这一步。节点上其他一切不受影响(`default_runtime_name` 仍然是 `runc`)。 |
+| `DaemonSet/nvidia-device-plugin-daemonset` | `apps/v1` | `kube-system` | 每个节点一个 Pod;通过 NVML 枚举物理 GPU,并通过一个 Unix socket(`/var/lib/kubelet/device-plugins/`)向 kubelet 注册 `nvidia.com/gpu` 这个资源。没有这个组件,Pod spec 里写的 `nvidia.com/gpu` 对调度器来说毫无意义——直接调度失败("Insufficient nvidia.com/gpu")。 |
+| `GatewayClass/agentgateway` | Gateway API | 集群级 | 声明"存在一个叫 `agentgateway.dev/agentgateway` 的控制器,能实现引用这个 class 的 `Gateway` 资源"。类比存储领域的 `StorageClass`。 |
+| `Gateway/llm-d-inference-gateway` | Gateway API | `llm-d` | 真正的监听器(这里是 80 端口),agentgateway 会把它编译进数据面代理的实际配置。`status.conditions[Programmed]=True` 意味着代理配置真的生成并生效了,而不只是这个对象被 API server 接受了而已。 |
+| `HTTPRoute/llm-d` | Gateway API | `llm-d` | 把上面那个 `Gateway` 上的一个路径前缀(`/`)绑定到一个 `backendRef`——而这个 backend 不是普通 `Service`,而是一个 `InferencePool`(见下一行)。这正是"通用 HTTP 网关"变成"推理感知网关"的扩展点。 |
+| `InferencePool/llm-d` | Gateway API Inference Extension | `llm-d` | llm-d 的核心抽象:"同一个模型的一组可互换的模型服务副本",通过 `spec.selector.matchLabels`(这里是 `llm-d.ai/guide: gpu-kind-native`)来标识——**这是一个 Pod 标签选择器,实时对着 Kubernetes 的 Pod API 求值,从来不经过 Service 的 VIP。** `spec.endpointPickerRef` 指向 EPP 的 Service:端口,由它来决定每个请求具体交给选中集合里的哪个 Pod。 |
+| `Deployment/llm-d-epp` | `apps/v1` | `llm-d` | Endpoint Picker(EPP)——一个 2 容器的 Pod(`epp` + `vllm-render` 分词器 sidecar)。实现了 agentgateway 每个请求都会调用的 `ext_proc` gRPC 协议;按配置好的插件链(见第 6 节)从 `InferencePool` 当前的成员集合里挑出目标 Pod IP。 |
+| `Deployment/vllm-qwen` | `apps/v1` | `llm-d` | 模型服务本体。唯一和 GPU 相关的字段就是 `spec.template.spec.runtimeClassName: nvidia` 和 `resources.limits.{nvidia.com/gpu: 1}`——其余部分就是一个彻头彻尾普通的 Deployment。 |
+| `Secret/llm-d-hf-token` | 核心 `v1` | `llm-d` | 一个(对公开模型来说是空的)Hugging Face token。EPP 的 `vllm-render` sidecar 容器在 chart 模板里无条件引用了这个环境变量;不建这个 Secret 的话 Pod 会报 `CreateContainerConfigError`,即便这个 token 对公开模型根本用不上。 |
+| `ServiceAccount/sa` | 核心 `v1` | `llm-d` | 工作负载 Pod 运行时使用的身份;设了 `automountServiceAccountToken: false`,因为本 demo 里没有任何 Pod 内部代码需要调用 Kubernetes API。 |
+
+## 6. 请求流程详解
+
+对照步骤 9 里那次 `curl` 测试,按顺序编号:
+
+1. **客户端 → Gateway Service。** `curl` 打到 `llm-d-inference-gateway` 的
+   `ClusterIP:80`。这是一个普通的 L4、`LoadBalancer` 类型的 Service(在
+   Kind 里外部 IP 一直是 pending 状态,没关系,我们直接打的是 ClusterIP),
+   它的 Endpoints 指向 `agentgateway` 那个数据面 Pod。
+2. **agentgateway 匹配 `HTTPRoute`。** 这个 `Gateway` 上路径 `/` 匹配到
+   `HTTPRoute/llm-d` 这条规则,它的 `backendRef` 是 `InferencePool/llm-d`,
+   而不是一个普通 Service。
+3. **agentgateway 在转发之前,先通过 `ext_proc`(gRPC)调用 EPP。** 因为安
+   装时设置了 `inferenceExtension.enabled=true`,agentgateway 知道
+   "backend 是 `InferencePool`"意味着"要问这个 EPP 该用哪个 Pod",而不是
+   "在 Service 的 Endpoints 之间做负载均衡"。
+4. **EPP 解析池子里的成员。** 它持续监听 Kubernetes 的 Pod API,找匹配
+   `InferencePool.spec.selector`(`llm-d.ai/guide: gpu-kind-native`)的
+   Pod——此刻正好只有一个,就是 `vllm-qwen` 这个 Pod。
+5. **EPP 跑打分插件链**(配置在
+   `helm-values/precise-prefix-router.values.yaml` 里):
+   - `token-producer`——通过 `vllm-render` sidecar 对输入 prompt 做分词,
+     让后面的插件能按真实 token 数量而不是字符数来判断。
+   - `precise-prefix-cache-producer`——维护一份"每个 Pod 上,vLLM 引擎当前
+     持有哪些 64-token KV-cache 块"的索引,**索引数据来自 vLLM 在 5556 端
+     口发布的真实 ZMQ 事件**(这正是步骤 8 里那条直接连到 `vllm-qwen` Pod
+     IP、不经过任何代理的订阅连接)。
+   - `prefix-cache-scorer`(权重 3.0)、`kv-cache-utilization-scorer`(权
+     重 2.0)、`queue-scorer`(权重 2.0)——给每个候选 Pod 打分;
+     `max-score-picker` 选出得分最高的那个。
+6. **EPP 通过同一次 `ext_proc` 调用,把选中 Pod 的 IP:端口返回给
+   agentgateway。**
+7. **agentgateway 把原始 HTTP 请求直接代理到 `vllm-qwen` 的 Pod IP**(本次
+   运行是 `10.244.0.10:8000`)——一次普通的集群内 L3/L4 跳转,不再经过任何
+   中间层。
+8. **vLLM 在真实的 GB10 GPU 上执行这个请求**,流式返回一个 OpenAI 兼容的响
+   应,原路返回给客户端。
+9. **旁路、持续发生的事情:** vLLM 每次分配或回收一个 KV-cache 块,都会在
+   5556 端口通过 ZMQ 发布一条"块新增/移除"事件;EPP 的
+   `precise-prefix-cache-producer` 独立消费这些事件,与任何具体请求无关,
+   持续保持索引最新——这样*下一个*请求的 `prefix-cache-scorer` 打分才是准
+   的。
+
+## 7. 清理
+
+```console
+$ kind delete cluster --name llm-d-gpu-kind
+```
+
+一条命令删掉整个集群(所有 Pod、节点容器、里面的 containerd/kubelet,全
+部)。它**不会**动宿主机上的 `/etc/docker/daemon.json` 或
+`/etc/nvidia-container-runtime/config.toml`——如果想把 Docker 的默认
+runtime 改回 `runc`,需要手动改这两个文件再 `sudo systemctl restart
+docker`(记得这次重启同样会停掉那些"裸"跑的容器,和步骤 2 一样)。
+
+## 8. 已知限制
+
+- **只支持单节点。** 多节点的 Kind-on-GPU 需要在每个节点上重复一遍同样的
+  GPU 穿透配置,而且只有每个节点都有自己独立的物理 GPU 时才有意义。
+- **GPU 显存是共享的、会变化的。** 这台 DGX Spark 的统一内存和主机上其他
+  GPU 工作负载共享(本次搭建全程还有两个 ComfyUI 进程和旧
+  `llm-d-gpu-demo` 的 `vllm-gpu-0` 在跑);今天能用的
+  `--gpu-memory-utilization` 值,明天不一定还够用。看到
+  `ValueError: No available memory for the cache blocks` 就调高这个值。
+- **两层容器嵌套需要保持同步。** 如果以后重新创建节点(比如升级 Docker 后
+  `kind delete && kind create`),步骤 4-5(在节点**内部**装
+  `nvidia-container-toolkit`、注册 `RuntimeClass`)都要重新做一遍——它们
+  不是原版 `kindest/node` 镜像自带的。
+- **本 demo 没有做自动扩缩容、链路追踪、P/D 分离** ——这些和"Kind 是不是
+  跑在 GPU 主机上"这个问题是正交的,`llm-d-gpu-demo` 里的 WVA/HPA、Jaeger、
+  P/D 章节已经分别覆盖过了。

--- a/llm-d/llm-d-gpu-kind/README.md
+++ b/llm-d/llm-d-gpu-kind/README.md
@@ -1,0 +1,710 @@
+# llm-d on Kind — Running Kind Directly on the GPU Host (No Proxy)
+
+This demo answers a follow-up question to
+[`../llm-d-gpu-demo`](../llm-d-gpu-demo): *"what if Kind itself ran on the GPU
+machine, instead of on a laptop that bridges to a remote GPU over a socat
+tunnel?"*
+
+**Answer: yes, and it removes an entire layer.** When Kind runs on the GPU
+host, vLLM becomes an ordinary Kubernetes `Deployment` — scheduled,
+health-checked, and restarted by kubelet, requesting `nvidia.com/gpu: 1`
+exactly the way a Pod requests `cpu` or `memory`. There is no socat bridge
+Pod, no external host to SSH into, no ZMQ tunnel — the EPP's KV-cache-event
+subscriber connects **directly to the vLLM Pod's IP**, in-cluster.
+
+This document is a from-scratch, command-by-command build log with real
+captured output, run on **2026-08-27** against an NVIDIA DGX Spark
+(GB10 Grace-Blackwell, aarch64, unified CPU/GPU memory). Every `console`
+block below is copy-pasted from the actual terminal session, not
+reconstructed after the fact — including the mistakes and crashes, because
+they're the most instructive part.
+
+中文版见 [`README-zh.md`](README-zh.md)。
+
+---
+
+## 1. What's different from `llm-d-gpu-demo`
+
+| | `llm-d-gpu-demo` | `llm-d-gpu-kind` (this demo) |
+|---|---|---|
+| Where Kind runs | Mac (Docker Desktop) | **On the GPU host itself** (Linux, DGX Spark) |
+| Where vLLM runs | `docker run` on the GPU host, **outside** Kind | A normal K8s `Deployment`, **inside** Kind |
+| How the EPP reaches vLLM | Through a 2-container `socat` proxy Pod tunneling to the external host over LAN | Directly, via the vLLM Pod's own cluster IP |
+| GPU as a K8s concept | Doesn't exist — GPU is invisible to the scheduler | `nvidia.com/gpu` is a real schedulable resource on the node |
+| Failure recovery | Manual (`docker restart` on the remote host) | Automatic (kubelet restarts the container per its restart policy) |
+| Extra moving parts | `gpu-vllm-proxy` Deployment + PodMonitor | None — one Deployment |
+
+The trade-off: this setup only works if Kind's control-plane node and the
+GPU are the same machine. If your GPU lives on a separate box from where you
+run `kind create cluster`, you're back to needing the proxy-bridge pattern
+from `llm-d-gpu-demo`.
+
+## 2. Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│ DGX Spark (192.168.1.112) — Ubuntu 24.04 aarch64, NVIDIA GB10        │
+│                                                                       │
+│  ┌───────────────────────────────────────────────────────────────┐  │
+│  │ Docker daemon (default-runtime = nvidia)                       │  │
+│  │                                                                 │  │
+│  │  ┌─────────────────────────────────────────────────────────┐  │  │
+│  │  │ Kind node container "llm-d-gpu-kind-control-plane"       │  │  │
+│  │  │ (has /dev/nvidia*, driver libs bind-mounted in;           │  │  │
+│  │  │  runs its own nested containerd + kubelet)                │  │  │
+│  │  │                                                            │  │  │
+│  │  │  containerd (RuntimeClass "nvidia" registered)             │  │  │
+│  │  │   │                                                        │  │  │
+│  │  │   ├─ Pod: agentgateway (data-plane proxy)  :80             │  │  │
+│  │  │   │      Gateway API + InferencePool aware                 │  │  │
+│  │  │   │                                                        │  │  │
+│  │  │   ├─ Pod: llm-d-epp (2 containers: epp + vllm-render)      │  │  │
+│  │  │   │      :9002 ext_proc gRPC, :9090 metrics                │  │  │
+│  │  │   │      subscribes ZMQ :5556 directly on vllm-qwen's IP   │  │  │
+│  │  │   │                                                        │  │  │
+│  │  │   ├─ Pod: vllm-qwen  (runtimeClassName: nvidia)             │  │  │
+│  │  │   │      resources.limits: {nvidia.com/gpu: 1}              │  │  │
+│  │  │   │      :8000 OpenAI HTTP API, :5556 ZMQ KV-cache events   │  │  │
+│  │  │   │      ── really executes on the GB10 GPU ──              │  │  │
+│  │  │   │                                                        │  │  │
+│  │  │   └─ DaemonSet: nvidia-device-plugin-daemonset (kube-system)│  │  │
+│  │  │          registers `nvidia.com/gpu` with kubelet            │  │  │
+│  │  └─────────────────────────────────────────────────────────┘  │  │
+│  └───────────────────────────────────────────────────────────────┘  │
+│                                                                       │
+│  (unrelated, pre-existing on this shared workstation:                │
+│   vllm-gpu-0 container from llm-d-gpu-demo, ComfyUI, Grafana, ...)   │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+Two levels of container nesting matter here, and the GPU has to be threaded
+through both:
+
+1. **Host Docker → Kind node container.** The node is "just" a Docker
+   container. For it to see the GPU, Docker's `nvidia` runtime has to inject
+   `/dev/nvidia*` and the driver libraries into it — same mechanism as
+   `docker run --gpus all`.
+2. **containerd (inside the node) → Pod container.** Kubernetes Pods aren't
+   started by the host's Docker at all; they're started by the *nested*
+   containerd running inside the node container. That nested containerd
+   needs its **own** copy of `nvidia-container-toolkit` and its own runtime
+   registration, or Pods inside Kind will never see the GPU even though the
+   node container can.
+
+Missing either layer is the single most common way this kind of setup fails
+silently (node has GPU, Pods don't, or vice versa).
+
+## 3. Prerequisites
+
+| Requirement | Why | Check |
+|---|---|---|
+| Linux host with NVIDIA GPU + driver | Kind's node-container GPU trick doesn't exist on Docker Desktop for Mac/Windows — there's no GPU passthrough into their Linux VM | `nvidia-smi` |
+| `nvidia-container-toolkit` installed on the host | Provides `nvidia-ctk` and the `nvidia-container-runtime` that Docker/containerd shell out to | `dpkg -l \| grep nvidia-container-toolkit` |
+| Docker with the current user in the `docker` group | We install kind/kubectl/helm without `sudo`, and drive `docker`/`kind`/`kubectl` without `sudo` | `docker ps` (no `sudo` needed) |
+| `sudo` access | Three **one-time** host-level config commands genuinely need root: editing `/etc/docker/daemon.json`, editing `/etc/nvidia-container-runtime/config.toml`, and `systemctl restart docker` | — |
+| Internet egress from the host | Pulls `kindest/node`, `nvcr.io/nvidia/vllm:26.05-py3` (~9.5 GB), the device-plugin image, and downloads the model from Hugging Face | `curl -sS -o /dev/null -w '%{http_code}\n' https://github.com` |
+
+Environment actually used below:
+
+```console
+$ uname -a
+Linux spark 6.14.0-1015-nvidia #15-Ubuntu SMP PREEMPT_DYNAMIC Tue Nov 25 18:02:16 UTC 2025 aarch64 aarch64 aarch64 GNU/Linux
+$ docker version --format '{{.Server.Version}}'
+28.5.1
+$ nvidia-smi --query-gpu=name,driver_version --format=csv
+name, driver_version
+NVIDIA GB10, 580.126.09
+```
+
+> **GB10 quirk you will hit later:** this chip has unified CPU/GPU memory, so
+> `nvidia-smi --query-gpu=memory.total` reports `[N/A]` and NVML's
+> `nvmlDeviceGetMemoryInfo()` call returns `Not Supported`. This breaks older
+> versions of the NVIDIA k8s device plugin outright (see Step 7).
+
+## 4. Step-by-step install
+
+### Step 1 — Install kind, kubectl, helm (no sudo)
+
+Installed to `~/bin` on the DGX Spark itself, since we don't have `sudo` for
+writing to `/usr/local/bin`:
+
+```console
+$ curl -sSL -o ~/bin/kind https://kind.sigs.k8s.io/dl/v0.31.0/kind-linux-arm64 && chmod +x ~/bin/kind
+$ ~/bin/kind version
+kind v0.31.0 go1.25.5 linux/arm64
+
+$ curl -sSL -o ~/bin/kubectl "https://dl.k8s.io/release/$(curl -sSL https://dl.k8s.io/release/stable.txt)/bin/linux/arm64/kubectl" && chmod +x ~/bin/kubectl
+$ ~/bin/kubectl version --client
+Client Version: v1.37.0
+
+$ HELM_INSTALL_DIR=~/bin bash <(curl -sSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3) --no-sudo
+$ ~/bin/helm version
+version.BuildInfo{Version:"v3.21.4", ...}
+```
+
+### Step 2 — Configure Docker for GPU passthrough
+
+**This step needs real root**, so it can't be automated blindly over a
+non-interactive SSH pipe (`sudo` needs a tty to prompt for a password). Run
+it with `ssh -t` so `sudo` can actually ask:
+
+```console
+$ sudo nvidia-ctk runtime configure --runtime=docker --set-as-default
+$ sudo sed -i 's/#accept-nvidia-visible-devices-as-volume-mounts = false/accept-nvidia-visible-devices-as-volume-mounts = true/' /etc/nvidia-container-runtime/config.toml
+$ sudo systemctl restart docker
+```
+
+What each line does:
+
+- `nvidia-ctk runtime configure --runtime=docker --set-as-default` writes
+  `/etc/docker/daemon.json` so Docker knows about an `nvidia` runtime *and*
+  makes it the default for every new container on this host:
+  ```json
+  {
+      "default-runtime": "nvidia",
+      "runtimes": { "nvidia": { "path": "nvidia-container-runtime", "args": [] } }
+  }
+  ```
+  `nvidia-container-runtime` is a thin wrapper around `runc`: for a container
+  with no GPU request, it behaves exactly like plain `runc`. It only injects
+  GPU devices/libraries when told to.
+- The `sed` line flips on
+  `accept-nvidia-visible-devices-as-volume-mounts`. This is the load-bearing
+  trick for the next step: **Kind has no `--gpus` flag**, so there's no
+  normal way to tell the runtime "this container wants the GPU." With this
+  setting on, the runtime treats a bind-mount whose *destination* matches
+  `/var/run/nvidia-container-devices/<name>` as equivalent to setting the
+  environment variable `NVIDIA_VISIBLE_DEVICES=<name>` — and Kind's cluster
+  config format *does* let you add arbitrary bind mounts (`extraMounts`).
+- `systemctl restart docker` applies the new default runtime.
+
+> ### ⚠️ Real incident: this restart killed an unrelated running container
+>
+> This DGX Spark already had a container called `vllm-gpu-0` running (the
+> real-GPU backend for `llm-d-gpu-demo`). `systemctl restart docker` is not
+> "add config, keep running" — Docker's default behavior (no
+> `--live-restore`) is to **stop every running container** during a clean
+> daemon shutdown, and containers started with plain `docker run -d` (no
+> `--restart` policy) do **not** come back on their own:
+> ```console
+> $ docker ps -a
+> CONTAINER ID   IMAGE                           STATUS                      NAMES
+> 5e4f32eba04a   nvcr.io/nvidia/vllm:26.05-py3   Exited (0) 22 seconds ago   vllm-gpu-0
+> ```
+> Fix: `docker start vllm-gpu-0` — but its old `--gpu-memory-utilization 0.03`
+> then failed to allocate KV-cache blocks (see the next callout), so it had
+> to be recreated with a slightly larger budget. **Lesson: `systemctl restart
+> docker` is not safe on a host with other unmanaged GPU containers on it —
+> either add `--restart=unless-stopped` to those containers ahead of time, or
+> expect to manually restart them.**
+
+### Step 3 — Create the Kind cluster with the GPU bind-mount trick
+
+`kind/kind-config.yaml`:
+
+```yaml
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: llm-d-gpu-kind
+nodes:
+- role: control-plane
+  extraMounts:
+  - hostPath: /dev/null
+    containerPath: /var/run/nvidia-container-devices/all
+  kubeadmConfigPatches:
+  - |
+    kind: KubeletConfiguration
+    maxPods: 250
+    evictionHard:
+      memory.available: "512Mi"
+```
+
+`hostPath: /dev/null` is arbitrary — the *destination* path is what the
+runtime hook reads, the *source* just has to be something that always
+exists. `all` as the mount's basename means "expose every GPU on this host."
+
+```console
+$ kind create cluster --config kind/kind-config.yaml
+Creating cluster "llm-d-gpu-kind" ...
+ ✓ Ensuring node image (kindest/node:v1.35.0) 🖼
+ ✓ Preparing nodes 📦
+ ✓ Writing configuration 📜
+ ✓ Starting control-plane 🕹️
+ ✓ Installing CNI 🔌
+ ✓ Installing StorageClass 💾
+Set kubectl context to "kind-llm-d-gpu-kind"
+```
+
+Verify the GPU actually made it into the node container — **this is Docker
+seeing the GPU, not Kubernetes yet**:
+
+```console
+$ docker exec llm-d-gpu-kind-control-plane ls -la /dev/ | grep -i nvidia
+crw-rw-rw-  1 root root  195, 254 nvidia-modeset
+crw-rw-rw-  1 root root  499,   0 nvidia-uvm
+crw-rw-rw-  1 root root  499,   1 nvidia-uvm-tools
+crw-rw-rw-  1 root root  195,   0 nvidia0
+crw-rw-rw-  1 root root  195, 255 nvidiactl
+
+$ docker exec llm-d-gpu-kind-control-plane nvidia-smi
+Thu Aug 27 11:23:06 2026
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 580.126.09    Driver Version: 580.126.09    CUDA Version: 13.0                |
+|   0  NVIDIA GB10   On  | 0000000F:01:00.0 Off |  N/A   50C  12W  0%  Default             |
++-----------------------------------------------------------------------------------------+
+```
+
+If that worked, `nvidia-ctk`'s driver-library mounts also came along for
+free (the runtime injects both the device nodes and the matching
+`libcuda.so`/`libnvidia-ml.so` etc. together).
+
+### Step 4 — Give the *nested* containerd GPU support too
+
+The node container can see the GPU, but Kubernetes Pods are started by the
+containerd running **inside** that node, which is a stock `kindest/node`
+image with no NVIDIA tooling at all yet. Install it there, using the node's
+own (working) internet access:
+
+```console
+$ docker exec llm-d-gpu-kind-control-plane bash -c '
+  apt-get install -y -qq curl gnupg
+  curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+  curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
+    sed "s#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g" | \
+    tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+  apt-get update -qq
+  apt-get install -y -qq nvidia-container-toolkit
+'
+```
+
+Then register an `nvidia` runtime handler in the **nested** containerd
+(deliberately *not* as the default — only Pods that explicitly opt in via
+`runtimeClassName: nvidia` should get GPU injection):
+
+```console
+$ docker exec llm-d-gpu-kind-control-plane nvidia-ctk runtime configure --runtime=containerd --config=/etc/containerd/config.toml
+INFO[...] Wrote updated config to /etc/containerd/conf.d/99-nvidia.toml
+INFO[...] It is recommended that containerd daemon be restarted.
+```
+
+> containerd 2.x supports drop-in config files under `/etc/containerd/conf.d/`
+> (imported via `imports = ["/etc/containerd/conf.d/*.toml"]` in the main
+> config) — `nvidia-ctk` wrote there instead of editing `config.toml`
+> directly. Either is fine; the drop-in is arguably cleaner.
+
+```console
+$ docker exec llm-d-gpu-kind-control-plane systemctl restart containerd
+$ docker exec llm-d-gpu-kind-control-plane systemctl is-active containerd
+active
+$ kubectl get nodes
+NAME                           STATUS   ROLES           AGE   VERSION
+llm-d-gpu-kind-control-plane   Ready    control-plane   20s   v1.35.0
+```
+
+Node stayed `Ready` through the containerd restart — kubelet reconnected on
+its own.
+
+Now tell Kubernetes about this runtime with a `RuntimeClass`:
+
+```console
+$ kubectl apply -f - <<'YAML'
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: nvidia
+handler: nvidia
+YAML
+runtimeclass.node.k8s.io/nvidia created
+```
+
+### Step 5 — Deploy the NVIDIA device plugin (and hit the GB10 bug)
+
+The device plugin is what turns "a GPU containerd can start Pods on" into
+"`nvidia.com/gpu` is a resource the scheduler knows about." First attempt,
+with a fairly recent but not-quite-latest image tag:
+
+```console
+$ kubectl apply -f manifests/nvidia-device-plugin.yaml   # v0.17.1 at this point
+$ kubectl -n kube-system logs -l name=nvidia-device-plugin-ds --tail 5
+E... error visiting device: error building Device: error getting device memory: Not Supported
+```
+
+Exactly the GB10 unified-memory quirk flagged in §3: the plugin calls
+`nvmlDeviceGetMemoryInfo()` to build its internal device map, GB10 returns
+`Not Supported` (it has no discrete VRAM to report), and v0.17.1 treats that
+as fatal. This is a
+[known, fixed issue](https://github.com/NVIDIA/k8s-device-plugin/issues/1482) —
+**v0.17.4+ tolerates the `Not Supported` response.** Bumping the tag:
+
+```console
+$ kubectl apply -f manifests/nvidia-device-plugin.yaml   # now v0.17.4
+$ kubectl -n kube-system logs -l name=nvidia-device-plugin-ds --tail 5
+W... devices.go:77] Ignoring error getting device memory: Not Supported
+I... server.go:195] Starting GRPC server for 'nvidia.com/gpu'
+I... server.go:146] Registered device plugin for 'nvidia.com/gpu' with Kubelet
+```
+
+Verify the node now advertises a real GPU resource:
+
+```console
+$ kubectl get node llm-d-gpu-kind-control-plane -o jsonpath='{.status.allocatable}' | tr ',' '\n' | grep gpu
+"nvidia.com/gpu":"1"
+```
+
+Prove it end-to-end with a plain smoke-test Pod — no llm-d involved yet,
+just "can a Pod that asks for `nvidia.com/gpu: 1` actually run `nvidia-smi`
+on the real GPU":
+
+```console
+$ kubectl apply -f - <<'YAML'
+apiVersion: v1
+kind: Pod
+metadata:
+  name: gpu-smoke-test
+spec:
+  restartPolicy: Never
+  runtimeClassName: nvidia
+  containers:
+  - name: cuda
+    image: nvcr.io/nvidia/cuda:13.0.1-base-ubuntu24.04
+    command: ["nvidia-smi"]
+    resources:
+      limits: { nvidia.com/gpu: 1 }
+YAML
+$ kubectl logs gpu-smoke-test
+Thu Aug 27 11:27:56 2026
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 580.126.09    Driver Version: 580.126.09    CUDA Version: 13.0                |
+|   0  NVIDIA GB10   On  | 0000000F:01:00.0 Off |  N/A   50C  12W  0%  Default             |
++-----------------------------------------------------------------------------------------+
+```
+
+**This is the milestone the whole demo is built around**: a normal
+`kubectl apply` Pod, scheduled by the default scheduler because it asked for
+`nvidia.com/gpu: 1`, running real code on the real GPU. No proxy, no
+external host, no `docker run` needed.
+
+### Step 6 — Namespace, CRDs, agentgateway, Gateway
+
+```console
+$ kubectl apply -f - <<'YAML'
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: llm-d
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa
+  namespace: llm-d
+automountServiceAccountToken: false
+YAML
+
+$ kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/standard-install.yaml
+$ kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/v1.5.0/v1-manifests.yaml
+$ kubectl apply -k "https://github.com/llm-d/llm-d-router/config/crd?ref=main"
+```
+
+These three commands install, respectively: **Gateway API** (`GatewayClass`,
+`Gateway`, `HTTPRoute` — Kubernetes' "next-gen Ingress"), **Gateway API
+Inference Extension / GAIE** (`InferencePool` — a resource type specifically
+for "a group of model-server replicas," which is what the EPP watches), and
+**llm-d's own CRDs** (`InferenceObjective`, `InferenceModelRewrite`).
+
+```console
+$ helm upgrade --install agentgateway-crds oci://cr.agentgateway.dev/charts/agentgateway-crds \
+  --namespace agentgateway-system --create-namespace --version v1.1.0
+
+$ helm upgrade --install agentgateway oci://cr.agentgateway.dev/charts/agentgateway \
+  --namespace agentgateway-system --create-namespace --version v1.1.0 \
+  --set inferenceExtension.enabled=true
+
+$ kubectl apply -k "https://github.com/llm-d/llm-d/guides/recipes/gateway/agentgateway?ref=main" -n llm-d
+gateway.gateway.networking.k8s.io/llm-d-inference-gateway created
+
+$ kubectl get gatewayclass agentgateway
+NAME           CONTROLLER                      ACCEPTED   AGE
+agentgateway   agentgateway.dev/agentgateway   True       2s
+
+$ kubectl get gateway -n llm-d
+NAME                      CLASS          ADDRESS   PROGRAMMED   AGE
+llm-d-inference-gateway   agentgateway             True         6s
+```
+
+`--set inferenceExtension.enabled=true` is the switch that makes agentgateway
+watch `InferencePool` resources natively and know how to call an EPP's
+`ext_proc` endpoint — without it you'd have to wire that up by hand with an
+`AgentgatewayPolicy`.
+
+### Step 7 — Deploy vLLM as a native GPU Deployment
+
+This replaces the entire `gpu-vllm-proxy` Deployment from `llm-d-gpu-demo`.
+Full manifest: [`manifests/vllm-gpu-native.yaml`](manifests/vllm-gpu-native.yaml).
+The parts that matter:
+
+```yaml
+spec:
+  template:
+    metadata:
+      labels:
+        llm-d.ai/role: decode
+        llm-d.ai/guide: gpu-kind-native   # <- EPP's selector matches this
+        llm-d.ai/model: Qwen2.5-1.5B-Instruct
+    spec:
+      serviceAccountName: sa
+      runtimeClassName: nvidia            # <- opt in to GPU injection
+      containers:
+        - name: vllm
+          image: nvcr.io/nvidia/vllm:26.05-py3
+          command: ["vllm", "serve", "Qwen/Qwen2.5-1.5B-Instruct"]
+          args:
+            - "--port=8000"
+            - "--block-size=64"
+            - "--gpu-memory-utilization=0.05"
+            - "--max-model-len=4096"
+            - "--enforce-eager"
+            - "--kv-events-config={...,\"endpoint\":\"tcp://*:5556\",...}"
+          resources:
+            limits: { nvidia.com/gpu: 1 }   # <- this is the whole trick
+```
+
+```console
+$ kubectl apply -f manifests/vllm-gpu-native.yaml
+deployment.apps/vllm-qwen created
+$ kubectl -n llm-d get pods -l llm-d.ai/guide=gpu-kind-native
+NAME                        READY   STATUS              RESTARTS   AGE
+vllm-qwen-66c85c6f4-hfbgd   0/1     ContainerCreating   0          0s
+```
+
+> ### ⚠️ Real incident #1: cold image pull takes minutes
+>
+> Kind's nested containerd has its **own image store**, completely separate
+> from the host Docker's cache — even though `vllm-gpu-0` had already pulled
+> this exact image outside Kind, the in-cluster Pod had to pull all
+> 9.5 GB again from scratch:
+> ```console
+> Normal  Pulling  kubelet  spec.containers{vllm}: Pulling image "nvcr.io/nvidia/vllm:26.05-py3"
+> Normal  Pulled   kubelet  Successfully pulled image ... in 2m58.136s. Image size: 9486739495 bytes.
+> ```
+>
+> ### ⚠️ Real incident #2: the Pod crashed once, then healed itself
+> ```console
+> $ kubectl -n llm-d get pods -l llm-d.ai/guide=gpu-kind-native
+> NAME                        READY   STATUS    RESTARTS      AGE
+> vllm-qwen-66c85c6f4-hfbgd   0/1     Running   1 (42s ago)   4m
+> ```
+> The first attempt hit the same KV-cache-memory error as the `vllm-gpu-0`
+> incident above (`ValueError: No available memory for the cache blocks`) —
+> unsurprising, since this GPU is momentarily shared with a second vLLM
+> engine *and* the host's ComfyUI sessions. **kubelet just restarted the
+> container per its default restart policy, and the second attempt
+> succeeded** — no `docker start` needed by a human this time. This is the
+> concrete, hands-on version of "Kubernetes manages the container's
+> lifecycle" from the original conceptual discussion this demo grew out of.
+
+```console
+$ kubectl -n llm-d wait --for=condition=Ready pod -l llm-d.ai/guide=gpu-kind-native --timeout=900s
+pod/vllm-qwen-66c85c6f4-hfbgd condition met
+$ kubectl -n llm-d get pods -l llm-d.ai/guide=gpu-kind-native
+NAME                        READY   STATUS    RESTARTS      AGE
+vllm-qwen-66c85c6f4-hfbgd   1/1     Running   1 (93s ago)   4m51s
+```
+
+### Step 8 — Install the router (EPP + InferencePool)
+
+```console
+$ kubectl create secret generic llm-d-hf-token -n llm-d \
+  --from-literal=HF_TOKEN="" --dry-run=client -o yaml | kubectl apply -f -
+
+$ helm install llm-d oci://ghcr.io/llm-d/charts/llm-d-router-gateway --version v0 \
+  -f helm-values/precise-prefix-router.values.yaml \
+  -f helm-values/gw-kind-gpu.values.yaml \
+  --set provider.name=none \
+  --set httpRoute.create=true \
+  --set httpRoute.inferenceGatewayName=llm-d-inference-gateway \
+  -n llm-d
+NAME: llm-d
+STATUS: deployed
+```
+
+`helm-values/gw-kind-gpu.values.yaml` sets
+`router.modelServers.matchLabels: {llm-d.ai/guide: gpu-kind-native}` — this
+one line is the entire connection between the EPP and the real vLLM Pod;
+everything else about routing (scoring, prefix-cache awareness) is generic
+and doesn't know or care that the backend happens to be a real GPU this
+time.
+
+```console
+$ kubectl -n llm-d get pods
+NAME                                       READY   STATUS    RESTARTS      AGE
+llm-d-epp-7c8c9f5b8d-tf7sm                 2/2     Running   0             5m17s
+llm-d-inference-gateway-86b846c879-4dcjb   1/1     Running   0             6m20s
+vllm-qwen-66c85c6f4-hfbgd                  1/1     Running   1 (2m ago)    5m57s
+```
+
+**The single most important log line in this whole demo** — proof the proxy
+layer is truly gone:
+
+```console
+$ kubectl -n llm-d logs deploy/llm-d-epp -c epp | grep zmq
+{"logger":"zmq-subscriber","msg":"Connected subscriber socket","endpoint":"tcp://10.244.0.10:5556"}
+```
+
+`10.244.0.10` is `vllm-qwen`'s own Pod IP. Compare to `llm-d-gpu-demo`,
+where this same log line pointed at the `gpu-vllm-proxy` Pod's IP, which
+then forwarded over LAN to a completely different machine.
+
+### Step 9 — End-to-end test through the Gateway
+
+```console
+$ GWIP=$(kubectl get svc llm-d-inference-gateway -n llm-d -o jsonpath='{.spec.clusterIP}')
+$ kubectl run trig --rm -i --restart=Never --image=curlimages/curl:8.7.1 -n llm-d -- \
+  curl -sS -X POST http://$GWIP:80/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"Qwen/Qwen2.5-1.5B-Instruct","messages":[{"role":"user","content":"Say hi in exactly three words."}],"max_tokens":20}'
+
+{"id":"chatcmpl-e343c7b9-7fc3-428c-a36f-7145163e22b7","object":"chat.completion",
+ "model":"Qwen/Qwen2.5-1.5B-Instruct",
+ "choices":[{"index":0,"message":{"role":"assistant","content":"Hello there!"},"finish_reason":"stop"}],
+ "usage":{"prompt_tokens":36,"completion_tokens":4,"total_tokens":40}}
+```
+
+A real completion, from a real GPU, through the full Gateway → EPP →
+InferencePool → Pod chain, on a cluster whose only non-standard ingredient
+is `runtimeClassName: nvidia` on one Deployment.
+
+Corresponding EPP-side log entry — same request, `x-request-id` matches the
+`chatcmpl-...` id above:
+
+```console
+$ kubectl -n llm-d logs deploy/llm-d-epp -c epp --tail 30 | grep prefix
+{"logger":"prefix","msg":"PrefixCacheMatchInfo not found for endpoints, assigning score 0",
+ "x-request-id":"e343c7b9-7fc3-428c-a36f-7145163e22b7","incomingModelName":"Qwen/Qwen2.5-1.5B-Instruct"}
+```
+
+(Score 0 because this was the very first request — nothing in the KV-cache
+index yet. A second request with an overlapping prompt prefix would score
+above 0 and get routed with that in mind; with only one backend Pod in this
+demo the scorer can't actually change *which* Pod gets picked, but the same
+mechanism is what drives real routing decisions once you scale to N
+replicas.)
+
+Confirms both vLLM engines are alive on the GPU simultaneously (this
+demo's `vllm-qwen` + the older `llm-d-gpu-demo`'s `vllm-gpu-0`, still
+running, undisturbed):
+
+```console
+$ nvidia-smi --query-compute-apps=pid,process_name,used_memory --format=csv
+pid, process_name, used_gpu_memory [MiB]
+3858903, VLLM::EngineCore, 6265 MiB
+3880364, VLLM::EngineCore, 5530 MiB
+```
+
+And the node's resource accounting now treats the GPU exactly like any other
+resource:
+
+```console
+$ kubectl describe node llm-d-gpu-kind-control-plane | sed -n '/Allocated resources/,/Events/p'
+Allocated resources:
+  Resource           Requests     Limits
+  --------           --------     ------
+  cpu                2950m (14%)  4100m (20%)
+  memory             8994Mi (7%)  6534Mi (5%)
+  nvidia.com/gpu     1            1
+```
+
+---
+
+## 5. What each component/CR actually is
+
+| Resource | Kind | Namespace | What it means here |
+|---|---|---|---|
+| `RuntimeClass/nvidia` | built-in K8s type | cluster-scoped | A named pointer to a containerd runtime handler. Any Pod that sets `spec.runtimeClassName: nvidia` gets its container created via `nvidia-container-runtime` instead of plain `runc`, which is what actually injects `/dev/nvidia*` + driver libs into that specific container. Everything else on the node is unaffected (`default_runtime_name` is still `runc`). |
+| `DaemonSet/nvidia-device-plugin-daemonset` | `apps/v1` | `kube-system` | One Pod per node; talks to NVML to enumerate physical GPUs and registers the `nvidia.com/gpu` resource with kubelet over a Unix socket (`/var/lib/kubelet/device-plugins/`). Without this, `nvidia.com/gpu` in a Pod spec is meaningless to the scheduler — it just fails to schedule ("Insufficient nvidia.com/gpu"). |
+| `GatewayClass/agentgateway` | Gateway API | cluster-scoped | Declares that a controller named `agentgateway.dev/agentgateway` exists and can fulfill `Gateway` resources that reference this class. Analogous to `StorageClass` for storage. |
+| `Gateway/llm-d-inference-gateway` | Gateway API | `llm-d` | The actual listener (port 80 here) that agentgateway programs into its data-plane proxy. `status.conditions[Programmed]=True` means the proxy config was actually generated and is live, not just that the object was accepted by the API server. |
+| `HTTPRoute/llm-d` | Gateway API | `llm-d` | Binds a path prefix (`/`) on the `Gateway` above to a `backendRef` — and that backend isn't a `Service`, it's an `InferencePool` (see next row). This is the extension point where "generic HTTP gateway" turns into "inference-aware gateway." |
+| `InferencePool/llm-d` | Gateway API Inference Extension | `llm-d` | The core llm-d abstraction: "a set of interchangeable model-server replicas for one model," identified by `spec.selector.matchLabels` (here: `llm-d.ai/guide: gpu-kind-native`) — **a Pod label selector, evaluated live against the Kubernetes Pod API, never a Service VIP.** `spec.endpointPickerRef` points at the EPP's Service:port that decides *which* matching Pod handles each request. |
+| `Deployment/llm-d-epp` | `apps/v1` | `llm-d` | The Endpoint Picker (EPP) — a 2-container Pod (`epp` + `vllm-render` tokenizer sidecar). Implements the `ext_proc` gRPC contract agentgateway calls into on every request; runs the configured plugin chain (see §6) to pick a target Pod IP from the `InferencePool`'s current member set. |
+| `Deployment/vllm-qwen` | `apps/v1` | `llm-d` | The model server itself. The only GPU-specific fields are `spec.template.spec.runtimeClassName: nvidia` and `resources.limits.{nvidia.com/gpu: 1}` — everything else is a completely ordinary Deployment. |
+| `Secret/llm-d-hf-token` | core `v1` | `llm-d` | An (empty, for a public model) Hugging Face token. The EPP's `vllm-render` sidecar container references this env var unconditionally in the chart template; omitting the Secret makes the Pod fail with `CreateContainerConfigError` even though the token itself is never used for a public model. |
+| `ServiceAccount/sa` | core `v1` | `llm-d` | Identity the workload Pods run as; `automountServiceAccountToken: false` because nothing in this demo calls the Kubernetes API from inside a Pod. |
+
+## 6. Request-flow walkthrough
+
+Numbered against the `curl` test in Step 9:
+
+1. **Client → Gateway Service.** `curl` hits `llm-d-inference-gateway`'s
+   `ClusterIP:80`. This Service is a plain L4 `LoadBalancer`-type Service
+   (pending an external IP in Kind, which is fine — we hit the ClusterIP
+   directly) whose Endpoints point at the `agentgateway` data-plane Pod.
+2. **agentgateway matches the `HTTPRoute`.** Path `/` on this `Gateway`
+   resolves to the `HTTPRoute/llm-d` rule, whose `backendRef` is
+   `InferencePool/llm-d`, not a normal Service.
+3. **agentgateway calls the EPP over `ext_proc` (gRPC), before forwarding
+   anywhere.** Because `inferenceExtension.enabled=true` was set at install
+   time, agentgateway knows that an `InferencePool` backend means "ask this
+   EPP which Pod to use" rather than "load-balance across a Service's
+   Endpoints."
+4. **EPP resolves pool membership.** It watches the Kubernetes Pod API for
+   Pods matching `InferencePool.spec.selector` (`llm-d.ai/guide:
+   gpu-kind-native`) — right now, that's exactly one Pod, `vllm-qwen`'s.
+5. **EPP runs its scoring plugin chain** (configured in
+   `helm-values/precise-prefix-router.values.yaml`):
+   - `token-producer` — tokenizes the incoming prompt (via the `vllm-render`
+     sidecar) so downstream plugins reason in real token counts, not
+     characters.
+   - `precise-prefix-cache-producer` — maintains a per-Pod index of which
+     64-token KV-cache blocks that Pod's vLLM engine currently holds,
+     **built from real ZMQ events vLLM publishes on port 5556** (this is
+     the subscription connected directly to `vllm-qwen`'s Pod IP, no proxy —
+     see Step 8).
+   - `prefix-cache-scorer` (weight 3.0), `kv-cache-utilization-scorer`
+     (weight 2.0), `queue-scorer` (weight 2.0) — score every candidate Pod;
+     `max-score-picker` picks the winner.
+6. **EPP returns the winning Pod's IP\:port to agentgateway** over the same
+   `ext_proc` call.
+7. **agentgateway proxies the original HTTP request to `vllm-qwen`'s Pod IP
+   directly** (`10.244.0.10:8000` in this run) — a plain in-cluster L3/L4
+   hop, no further indirection.
+8. **vLLM executes the request on the real GB10 GPU** and streams back an
+   OpenAI-compatible response, which retraces the same path to the client.
+9. **Side channel, continuously:** vLLM publishes a KV-cache-block-added/
+   removed event over ZMQ on port 5556 every time it allocates or evicts a
+   cache block; the EPP's `precise-prefix-cache-producer` consumes this
+   independently of any particular request, keeping its index current for
+   the *next* request's `prefix-cache-scorer` decision.
+
+## 7. Cleanup
+
+```console
+$ kind delete cluster --name llm-d-gpu-kind
+```
+
+This removes the entire cluster (all Pods, the node container, its
+containerd/kubelet, everything) in one step. It does **not** touch
+`/etc/docker/daemon.json` or `/etc/nvidia-container-runtime/config.toml` on
+the host — if you want Docker's default runtime back to `runc`, edit those
+by hand and `sudo systemctl restart docker` again (and remember the restart
+will stop unmanaged containers, same as in Step 2).
+
+## 8. Known limitations
+
+- **Single node only.** Multi-node Kind-on-GPU setups need this same GPU
+  passthrough repeated per node, and only make sense if each node has its
+  own physical GPU.
+- **GPU memory is a shared, moving target.** This DGX Spark's unified memory
+  is shared with the host's other GPU workloads (this session ran alongside
+  two ComfyUI processes and the older `llm-d-gpu-demo`'s `vllm-gpu-0`); the
+  `--gpu-memory-utilization` value that works today may not tomorrow. Watch
+  for `ValueError: No available memory for the cache blocks` and raise it.
+- **Two levels of container nesting to keep in sync.** If you ever
+  re-provision the node (e.g. `kind delete && kind create` after a Docker
+  upgrade), Steps 4–5 (installing `nvidia-container-toolkit` *inside* the
+  node and registering the `RuntimeClass`) have to be redone — they're not
+  part of the stock `kindest/node` image.
+- **No autoscaling, tracing, or P/D disaggregation in this demo** — those
+  are orthogonal to the "is Kind on the GPU host" question this demo
+  answers, and are already covered by `llm-d-gpu-demo`'s WVA/HPA, Jaeger, and
+  P/D sections respectively.

--- a/llm-d/llm-d-gpu-kind/helm-values/gw-kind-gpu.values.yaml
+++ b/llm-d/llm-d-gpu-kind/helm-values/gw-kind-gpu.values.yaml
@@ -1,0 +1,27 @@
+## Resource + selector overrides for the router release "llm-d" on the
+## GPU-Kind single-node cluster (DGX Spark). Trimmed CPU/memory requests so
+## EPP + its tokenizer sidecar fit comfortably alongside the real vLLM Pod on
+## one node.
+router:
+  epp:
+    replicas: 1
+    image:
+      registry: ghcr.io/llm-d
+      repository: llm-d-router-endpoint-picker
+      tag: main
+      pullPolicy: IfNotPresent
+    resources:
+      requests: { cpu: "500m", memory: "512Mi" }
+      limits:   { cpu: "2", memory: "2Gi" }
+    flags:
+      v: 2
+  tokenizer:
+    resources:
+      requests: { cpu: "500m", memory: "2Gi" }
+      limits:   { cpu: "2", memory: "4Gi" }
+  modelServers:
+    matchLabels:
+      llm-d.ai/guide: "gpu-kind-native"
+  monitoring:
+    prometheus:
+      enabled: false

--- a/llm-d/llm-d-gpu-kind/helm-values/precise-prefix-router.values.yaml
+++ b/llm-d/llm-d-gpu-kind/helm-values/precise-prefix-router.values.yaml
@@ -1,0 +1,64 @@
+## EPP precise prefix-cache (KV-cache-aware) routing config for the REAL GPU
+## vLLM backend (via gpu-vllm-proxy). Layer this onto the helm install
+## INSTEAD OF a baseline/optimized-baseline plugin config.
+##
+## Model servers publish KV-cache events over ZMQ (per-pod socket :5556,
+## tunneled from the DGX Spark by gpu-vllm-proxy's kv-proxy container) and
+## the EPP's precise-prefix-cache-producer builds a per-pod block index
+## consumed by the prefix-cache-scorer -- this is the real KV-cache-aware
+## routing loop, now backed by real GPU inference instead of CPU/sim.
+##
+## Adapted from llm-d-full-demo's manifests/optional/precise-prefix/ (same
+## plugin chain); only the model name changed (Qwen2.5-0.5B -> 1.5B-Instruct).
+router:
+  tokenizer:
+    enabled: true
+    modelName: Qwen/Qwen2.5-1.5B-Instruct  # must match the deployed model + token-producer below
+
+  epp:
+    pluginsConfigFile: "precise-prefix-cache-routing-plugins.yaml"
+    pluginsCustomConfig:
+      precise-prefix-cache-routing-plugins.yaml: |
+        apiVersion: llm-d.ai/v1alpha1
+        kind: EndpointPickerConfig
+        plugins:
+          - type: token-producer
+            parameters:
+              modelName: Qwen/Qwen2.5-1.5B-Instruct
+              vllm:
+                url: "http://localhost:8000"
+          - type: endpoint-notification-source
+          - type: precise-prefix-cache-producer
+            parameters:
+              tokenProcessorConfig:
+                blockSize: 64  # must match vLLM --block-size on the DGX Spark
+              speculativeIndexing: true
+              indexerConfig:
+                kvBlockIndexConfig:
+                  enableMetrics: true
+              kvEventsConfig:
+                topicFilter: "kv@"
+                concurrency: 8
+                discoverPods: true
+                podDiscoveryConfig:
+                  socketPort: 5556
+          - type: prefix-cache-scorer
+            parameters:
+              prefixMatchInfoProducerName: precise-prefix-cache-producer
+          - type: kv-cache-utilization-scorer
+          - type: queue-scorer
+          - type: no-hit-lru-scorer
+        dataLayer:
+          sources:
+            - pluginRef: endpoint-notification-source
+              extractors:
+                - pluginRef: precise-prefix-cache-producer
+        schedulingProfiles:
+          - name: default
+            plugins:
+              - pluginRef: kv-cache-utilization-scorer
+                weight: 2.0
+              - pluginRef: queue-scorer
+                weight: 2.0
+              - pluginRef: prefix-cache-scorer
+                weight: 3.0

--- a/llm-d/llm-d-gpu-kind/kind/kind-config.yaml
+++ b/llm-d/llm-d-gpu-kind/kind/kind-config.yaml
@@ -1,0 +1,22 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: llm-d-gpu-kind
+nodes:
+- role: control-plane
+  # This is the "magic mount" trick: Kind has no --gpus flag, so there is no
+  # normal way to tell the nvidia-container-runtime "give this node container
+  # access to the GPU". But with
+  # accept-nvidia-visible-devices-as-volume-mounts=true set on the host (see
+  # setup-gpu-docker.sh), the runtime treats a bind-mount whose destination
+  # matches /var/run/nvidia-container-devices/<name> as equivalent to setting
+  # NVIDIA_VISIBLE_DEVICES=<name>. Mounting host's /dev/null (always exists,
+  # content irrelevant) at .../all means "expose all GPUs to this container".
+  extraMounts:
+  - hostPath: /dev/null
+    containerPath: /var/run/nvidia-container-devices/all
+  kubeadmConfigPatches:
+  - |
+    kind: KubeletConfiguration
+    maxPods: 250
+    evictionHard:
+      memory.available: "512Mi"

--- a/llm-d/llm-d-gpu-kind/manifests/nvidia-device-plugin.yaml
+++ b/llm-d/llm-d-gpu-kind/manifests/nvidia-device-plugin.yaml
@@ -1,0 +1,56 @@
+# NVIDIA device plugin for Kubernetes.
+#
+# This is the component that turns "a GPU that Linux can see" into
+# "a schedulable Kubernetes resource". It runs as a DaemonSet, one Pod per
+# node; on each node it:
+#   1. talks to nvidia-container-runtime / NVML to enumerate physical GPUs
+#   2. registers a resource named `nvidia.com/gpu` with that node's kubelet
+#      over the kubelet device-plugin gRPC socket
+#      (/var/lib/kubelet/device-plugins/kubelet.sock)
+#   3. when the scheduler places a Pod that requests `nvidia.com/gpu: 1`, the
+#      device plugin tells kubelet which physical device to hand that Pod,
+#      and nvidia-container-runtime (registered as the `nvidia` RuntimeClass
+#      in this cluster) injects the actual /dev/nvidia* nodes + driver
+#      libraries into that Pod's container at creation time.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nvidia-device-plugin-daemonset
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      name: nvidia-device-plugin-ds
+  template:
+    metadata:
+      labels:
+        name: nvidia-device-plugin-ds
+    spec:
+      runtimeClassName: nvidia
+      tolerations:
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
+      priorityClassName: system-node-critical
+      containers:
+      # v0.17.1 crashes on DGX Spark / GB10 (Grace-Blackwell unified memory):
+      # nvmlDeviceGetMemoryInfo returns "Not Supported" on UMA hardware and
+      # older plugin builds treat that as fatal. Fixed in v0.17.4+, which
+      # tolerates the "Not Supported" memory query and still registers the
+      # GPU as `nvidia.com/gpu`.
+      - image: nvcr.io/nvidia/k8s-device-plugin:v0.17.4
+        name: nvidia-device-plugin-ctr
+        env:
+        - name: FAIL_ON_INIT_ERROR
+          value: "false"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        volumeMounts:
+        - name: device-plugin
+          mountPath: /var/lib/kubelet/device-plugins
+      volumes:
+      - name: device-plugin
+        hostPath:
+          path: /var/lib/kubelet/device-plugins

--- a/llm-d/llm-d-gpu-kind/manifests/vllm-gpu-native.yaml
+++ b/llm-d/llm-d-gpu-kind/manifests/vllm-gpu-native.yaml
@@ -1,0 +1,80 @@
+# The real GPU model server, running as an ordinary Kubernetes Deployment.
+#
+# This is the whole point of this demo: compared to llm-d-gpu-demo (where the
+# real vLLM process lives outside Kind on a separate machine, reached through
+# a socat tunnel Pod), Kind itself now runs ON the GPU host, so this Pod is
+# scheduled, health-checked, and restarted by kubelet exactly like any other
+# workload -- `nvidia.com/gpu: 1` in resources.limits is the only GPU-specific
+# thing here. The EPP finds this Pod the same way it would find a CPU Pod:
+# via the label selector below (router.modelServers.matchLabels in the helm
+# values), never via a Service VIP.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vllm-qwen
+  namespace: llm-d
+  labels:
+    llm-d.ai/role: decode
+    llm-d.ai/guide: gpu-kind-native
+    llm-d.ai/model: Qwen2.5-1.5B-Instruct
+    app.kubernetes.io/part-of: llm-d
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      llm-d.ai/guide: gpu-kind-native
+      llm-d.ai/role: decode
+  template:
+    metadata:
+      labels:
+        llm-d.ai/role: decode
+        llm-d.ai/guide: gpu-kind-native
+        llm-d.ai/model: Qwen2.5-1.5B-Instruct
+        app.kubernetes.io/part-of: llm-d
+    spec:
+      serviceAccountName: sa
+      runtimeClassName: nvidia
+      containers:
+        - name: vllm
+          image: nvcr.io/nvidia/vllm:26.05-py3
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VLLM_LOGGING_LEVEL
+              value: "INFO"
+          command: ["vllm", "serve", "Qwen/Qwen2.5-1.5B-Instruct"]
+          args:
+            - "--port=8000"
+            - "--block-size=64"
+            - "--gpu-memory-utilization=0.05"
+            - "--max-model-len=4096"
+            - "--enforce-eager"
+            - "--kv-events-config={\"enable_kv_cache_events\":true,\"publisher\":\"zmq\",\"endpoint\":\"tcp://*:5556\",\"topic\":\"kv@vllm-qwen:8000@Qwen/Qwen2.5-1.5B-Instruct\"}"
+          ports:
+            - name: modelserver
+              containerPort: 8000
+              protocol: TCP
+            - name: kv-events
+              containerPort: 5556
+              protocol: TCP
+          resources:
+            limits:
+              nvidia.com/gpu: 1
+            requests:
+              cpu: "1"
+              memory: "6Gi"
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: modelserver
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: modelserver
+            initialDelaySeconds: 60
+            periodSeconds: 20


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a GPU-enabled Kind deployment that runs vLLM directly on NVIDIA hardware with Kubernetes GPU scheduling.
  - Added native GPU deployment manifests, routing configuration, device-plugin setup, and cluster configuration.
  - Added comprehensive English and Chinese setup guides, request-lifecycle documentation, troubleshooting notes, and cleanup instructions.

- **Bug Fixes**
  - Updated router chart configuration after an upstream chart rename.
  - Updated disaggregated prefill/decode routing configuration to match the latest plugin format.
  - Documented observability and tracing updates from the latest demo rerun.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->